### PR TITLE
Fix broken and legacy documentation links across samples (1,166 links)

### DIFF
--- a/AI Invoice Parser/AWS Lambda/AI Invoice Parsing (Node.js)/app.js
+++ b/AI Invoice Parser/AWS Lambda/AI Invoice Parsing (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/AWS Lambda/AI Invoice Parsing with Webhook (Node.js)/app.js
+++ b/AI Invoice Parser/AWS Lambda/AI Invoice Parsing with Webhook (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/C#/AI Invoice Parsing with Webhook/Program.cs
+++ b/AI Invoice Parser/C#/AI Invoice Parsing with Webhook/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/C#/AI Invoice Parsing with Webhook/Properties/AssemblyInfo.cs
+++ b/AI Invoice Parser/C#/AI Invoice Parsing with Webhook/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/C#/AI Invoice Parsing/Program.cs
+++ b/AI Invoice Parser/C#/AI Invoice Parsing/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/C#/AI Invoice Parsing/Properties/AssemblyInfo.cs
+++ b/AI Invoice Parser/C#/AI Invoice Parsing/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/Java/AI Invoice Parsing with Webhook/src/com/company/Main.java
+++ b/AI Invoice Parser/Java/AI Invoice Parsing with Webhook/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/Java/AI Invoice Parsing/src/com/company/Main.java
+++ b/AI Invoice Parser/Java/AI Invoice Parsing/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -56,7 +56,7 @@ public class Main {
         RequestBody body = RequestBody.create(MediaType.parse("application/json"), jsonBody.toString());
 
         // Prepare URL for AI Invoice Parser API call.
-        // See documentation: https://docs.pdf.co/api/ai-invoice-parser/index.html
+        // See documentation: https://docs.pdf.co/api-reference/ai-invoice-parser
         String query = "https://api.pdf.co/v1/ai-invoice-parser";
 
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern("MM/dd/yyyy HH:mm:ss");

--- a/AI Invoice Parser/JavaScript/AI Invoice Parsing (Node.js)/app.js
+++ b/AI Invoice Parser/JavaScript/AI Invoice Parsing (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/AI Invoice Parser/JavaScript/AI Invoice Parsing with Webhook (Node.js)/app.js
+++ b/AI Invoice Parser/JavaScript/AI Invoice Parsing with Webhook (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/AWS Lambda/Add Image to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/AWS Lambda/Add Image to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/AWS Lambda/Add Text to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/AWS Lambda/Add Text to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -10,7 +10,7 @@
 
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 var https = require("https");
 

--- a/Add Text And Images To PDF/C#/Add Image by finding target coordinates/Program.cs
+++ b/Add Text And Images To PDF/C#/Add Image by finding target coordinates/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/C#/Add Images to Existing PDF/Program.cs
+++ b/Add Text And Images To PDF/C#/Add Images to Existing PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/C#/Add Text by finding target coordinates/Program.cs
+++ b/Add Text And Images To PDF/C#/Add Text by finding target coordinates/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 namespace ByteScoutWebApiExample
 {
@@ -60,7 +60,7 @@ namespace ByteScoutWebApiExample
             var X = coordinates.X;
             var Y = coordinates.Y + 25;
 
-            // See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+            // See documentation: https://docs.pdf.co/api-reference/pdf-add
             // Prepare requests params as JSON
             string jsonPayload = $@"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
@@ -133,7 +133,7 @@ namespace ByteScoutWebApiExample
             webClient.Headers.Add("x-api-key", apiKey);
 
             // Prepare requests params as JSON
-            // See documentation: https://docs.pdf.co/07-pdf-search-text
+            // See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
             Dictionary<string, string> parameters = new Dictionary<string, string>();
             parameters.Add("url", sourceFileUrl);
             parameters.Add("searchString", searchString);

--- a/Add Text And Images To PDF/C#/Add Text by finding target coordinates/README.md
+++ b/Add Text And Images To PDF/C#/Add Text by finding target coordinates/README.md
@@ -183,7 +183,7 @@ namespace ByteScoutWebApiExample
             var X = coordinates.X;
             var Y = coordinates.Y + 25;
 
-            // See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+            // See documentation: https://docs.pdf.co/api-reference/pdf-add
             // Prepare requests params as JSON
             string jsonPayload = $@"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
@@ -256,7 +256,7 @@ namespace ByteScoutWebApiExample
             webClient.Headers.Add("x-api-key", apiKey);
 
             // Prepare requests params as JSON
-            // See documentation: https://docs.pdf.co/07-pdf-search-text
+            // See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
             Dictionary<string, string> parameters = new Dictionary<string, string>();
             parameters.Add("url", sourceFileUrl);
             parameters.Add("searchString", searchString);

--- a/Add Text And Images To PDF/C#/Add Text to Existing PDF/Program.cs
+++ b/Add Text And Images To PDF/C#/Add Text to Existing PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -16,7 +16,7 @@ using System.IO;
 using System.Net;
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 namespace ByteScoutWebApiExample
 {
@@ -58,7 +58,7 @@ namespace ByteScoutWebApiExample
 			// * Add text annotation *
 
 			// Prepare requests params as JSON
-			// See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+			// See documentation: https://docs.pdf.co/api-reference/pdf-add
             string jsonPayload = $@"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/C#/Add Text to Existing PDF/README.md
+++ b/Add Text And Images To PDF/C#/Add Text to Existing PDF/README.md
@@ -181,7 +181,7 @@ namespace ByteScoutWebApiExample
 			// * Add text annotation *
 
 			// Prepare requests params as JSON
-			// See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+			// See documentation: https://docs.pdf.co/api-reference/pdf-add
             string jsonPayload = $@"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/GoogleAppScript/Add Text to PDF/program.gs
+++ b/Add Text And Images To PDF/GoogleAppScript/Add Text to PDF/program.gs
@@ -1,5 +1,5 @@
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // Handle PDF.co Menu on Google Sheet Open Event
 function onOpen() {

--- a/Add Text And Images To PDF/Java/Add Image by finding target coordinates/src/com/company/Main.java
+++ b/Add Text And Images To PDF/Java/Add Image by finding target coordinates/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/Java/Add Images to Existing PDF/src/com/company/Main.java
+++ b/Add Text And Images To PDF/Java/Add Images to Existing PDF/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/Java/Add Text by finding target coordinates/src/com/company/Main.java
+++ b/Add Text And Images To PDF/Java/Add Text by finding target coordinates/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/Java/Add Text to Existing PDF/src/com/company/Main.java
+++ b/Add Text And Images To PDF/Java/Add Text to Existing PDF/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/JavaScript/Add Image by finding target coordinates (Node.js)/README.md
+++ b/Add Text And Images To PDF/JavaScript/Add Image by finding target coordinates (Node.js)/README.md
@@ -49,7 +49,7 @@ const SourceFileUrl = "https://bytescout-com.s3.amazonaws.com/files/demo-files/c
 const SearchString = 'Your Company Name';
 
 // Prepare URL for PDF text search API call.
-// See documentation: https://docs.pdf.co/07-pdf-search-text
+// See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
 var queryFindText = `/v1/pdf/find`;
 
 // JSON payload for find text

--- a/Add Text And Images To PDF/JavaScript/Add Image by finding target coordinates (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Image by finding target coordinates (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -25,7 +25,7 @@ const SourceFileUrl = "https://bytescout-com.s3.amazonaws.com/files/demo-files/c
 const SearchString = 'Your Company Name';
 
 // Prepare URL for PDF text search API call.
-// See documentation: https://docs.pdf.co/07-pdf-search-text
+// See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
 var queryFindText = `/v1/pdf/find`;
 
 // JSON payload for find text

--- a/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF (jQuery)/addImageToPDF.js
+++ b/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF (jQuery)/addImageToPDF.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF Base64 (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Image to Existing PDF Base64 (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/JavaScript/Add Page Numbers and Page Count to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Page Numbers and Page Count to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -14,7 +14,7 @@ var path = require("path");
 var fs = require("fs");
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // The authentication key (API Key).
 // Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/JavaScript/Add Template Text With Data to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Template Text With Data to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -14,7 +14,7 @@ var path = require("path");
 var fs = require("fs");
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // The authentication key (API Key).
 // Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/JavaScript/Add Text With Line Breaks to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Text With Line Breaks to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -14,7 +14,7 @@ var path = require("path");
 var fs = require("fs");
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // The authentication key (API Key).
 // Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/JavaScript/Add Text by finding target coordinates (Node.js)/README.md
+++ b/Add Text And Images To PDF/JavaScript/Add Text by finding target coordinates (Node.js)/README.md
@@ -49,7 +49,7 @@ const SourceFileUrl = "https://bytescout-com.s3.amazonaws.com/files/demo-files/c
 const SearchString = 'Notes';
 
 // Prepare URL for PDF text search API call.
-// See documentation: https://docs.pdf.co/07-pdf-search-text
+// See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
 var queryFindText = `/v1/pdf/find`;
 
 // JSON payload for find text

--- a/Add Text And Images To PDF/JavaScript/Add Text by finding target coordinates (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Text by finding target coordinates (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -14,7 +14,7 @@ var path = require("path");
 var fs = require("fs");
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // The authentication key (API Key).
 // Get your own by registering at https://app.pdf.co
@@ -28,7 +28,7 @@ const SourceFileUrl = "https://bytescout-com.s3.amazonaws.com/files/demo-files/c
 const SearchString = 'Notes';
 
 // Prepare URL for PDF text search API call.
-// See documentation: https://docs.pdf.co/07-pdf-search-text
+// See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
 var queryFindText = `/v1/pdf/find`;
 
 // JSON payload for find text

--- a/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -10,7 +10,7 @@
 
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 var https = require("https");
 var path = require("path");

--- a/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF (jQuery)/addTextToPDF.js
+++ b/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF (jQuery)/addTextToPDF.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -10,7 +10,7 @@
 
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 $(document).ready(function () {
     $("#resultBlock").hide();

--- a/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF Base64 (Node.js)/app.js
+++ b/Add Text And Images To PDF/JavaScript/Add Text to Existing PDF Base64 (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -14,7 +14,7 @@ var path = require("path");
 var fs = require("fs");
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // `request` module is required for file upload.
 // Use "npm install request" command to install.

--- a/Add Text And Images To PDF/PHP/Add Template Text With Data to Existing PDF/sample.php
+++ b/Add Text And Images To PDF/PHP/Add Template Text With Data to Existing PDF/sample.php
@@ -1,7 +1,7 @@
 <?php
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 $curl = curl_init();
 

--- a/Add Text And Images To PDF/PHP/Add Text Image to PDF Simplified/sample.php
+++ b/Add Text And Images To PDF/PHP/Add Text Image to PDF Simplified/sample.php
@@ -1,7 +1,7 @@
 <?php
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 $curl = curl_init();
 

--- a/Add Text And Images To PDF/PHP/Add Text Images to PDF/sample.php
+++ b/Add Text And Images To PDF/PHP/Add Text Images to PDF/sample.php
@@ -1,7 +1,7 @@
 <?php
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 $curl = curl_init();
 

--- a/Add Text And Images To PDF/PHP/Add Text With Line Breaks to Existing PDF/sample.php
+++ b/Add Text And Images To PDF/PHP/Add Text With Line Breaks to Existing PDF/sample.php
@@ -1,7 +1,7 @@
 <?php
 
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 $curl = curl_init();
 

--- a/Add Text And Images To PDF/Python/Add Text And Image To PDF/AddTextAndImageToExistingPDF.py
+++ b/Add Text And Images To PDF/Python/Add Text And Image To PDF/AddTextAndImageToExistingPDF.py
@@ -2,7 +2,7 @@ import os
 import requests # pip install requests
 
 # Visit Knowledgebase for adding Text Macros to PDF 
-# https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+# https://docs.pdf.co/api-reference/pdf-add#macros
 
 # The authentication key (API Key).
 # Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/Python/Add Text by finding target coordinates/AddTextByFindingTargetCoordinates.py
+++ b/Add Text And Images To PDF/Python/Add Text by finding target coordinates/AddTextByFindingTargetCoordinates.py
@@ -2,7 +2,7 @@ import os
 import requests # pip install requests
 
 # Visit Knowledgebase for adding Text Macros to PDF 
-# https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+# https://docs.pdf.co/api-reference/pdf-add#macros
 
 # The authentication key (API Key).
 # Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/Python/Add Text to Existing PDF/AddTextToExistingPDF.py
+++ b/Add Text And Images To PDF/Python/Add Text to Existing PDF/AddTextToExistingPDF.py
@@ -2,7 +2,7 @@ import os
 import requests # pip install requests
 
 # Visit Knowledgebase for adding Text Macros to PDF 
-# https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+# https://docs.pdf.co/api-reference/pdf-add#macros
 
 # The authentication key (API Key).
 # Get your own by registering at https://app.pdf.co

--- a/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/README.md
+++ b/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/README.md
@@ -178,7 +178,7 @@ namespace AddTextAndImagesToPDFWebPart.VisualWebPart1
             // * Add text annotation *
 
             // Prepare requests params as JSON
-            // See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+            // See documentation: https://docs.pdf.co/api-reference/pdf-add
             string jsonPayload = $@"{{
                                         ""name"": ""{DestinationFile}"",
                                         ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/Utils.cs
+++ b/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/Utils.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/VisualWebPart1.cs
+++ b/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/VisualWebPart1.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
+++ b/Add Text And Images To PDF/SharePoint/Add Text and Images to PDF/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -76,7 +76,7 @@ namespace AddTextAndImagesToPDFWebPart.VisualWebPart1
             // * Add text annotation *
 
             // Prepare requests params as JSON
-            // See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+            // See documentation: https://docs.pdf.co/api-reference/pdf-add
             string jsonPayload = $@"{{
                                         ""name"": ""{DestinationFile}"",
                                         ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/VB.NET/Add Image by finding target coordinates/Module1.vb
+++ b/Add Text And Images To PDF/VB.NET/Add Image by finding target coordinates/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -61,7 +61,7 @@ Module Module1
         Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",
@@ -128,7 +128,7 @@ Module Module1
         webClient.Headers.Add("Content-Type", "application/json")
 
         ' Prepare URL for PDF text search API call.
-        ' See documentation: https://docs.pdf.co/07-pdf-search-text
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
         Dim url As String = "https://api.pdf.co/v1/pdf/find"
 
         ' Prepare requests params as JSON

--- a/Add Text And Images To PDF/VB.NET/Add Image by finding target coordinates/README.md
+++ b/Add Text And Images To PDF/VB.NET/Add Image by finding target coordinates/README.md
@@ -206,7 +206,7 @@ Module Module1
         Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",
@@ -273,7 +273,7 @@ Module Module1
         webClient.Headers.Add("Content-Type", "application/json")
 
         ' Prepare URL for PDF text search API call.
-        ' See documentation: https://docs.pdf.co/07-pdf-search-text
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
         Dim url As String = "https://api.pdf.co/v1/pdf/find"
 
         ' Prepare requests params as JSON

--- a/Add Text And Images To PDF/VB.NET/Add Images to Existing PDF/Module1.vb
+++ b/Add Text And Images To PDF/VB.NET/Add Images to Existing PDF/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -55,7 +55,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/VB.NET/Add Images to Existing PDF/README.md
+++ b/Add Text And Images To PDF/VB.NET/Add Images to Existing PDF/README.md
@@ -200,7 +200,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/VB.NET/Add Text by finding target coordinates/Module1.vb
+++ b/Add Text And Images To PDF/VB.NET/Add Text by finding target coordinates/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -15,7 +15,7 @@ Imports Newtonsoft.Json
 Imports Newtonsoft.Json.Linq
 
 ' Visit Knowledgebase for adding Text Macros to PDF 
-' https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+' https://docs.pdf.co/api-reference/pdf-add#macros
 
 Module Module1
 
@@ -66,7 +66,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",
@@ -134,7 +134,7 @@ Module Module1
         webClient.Headers.Add("Content-Type", "application/json")
 
         ' Prepare URL for PDF text search API call.
-        ' See documentation: https://docs.pdf.co/07-pdf-search-text
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
         Dim url As String = "https://api.pdf.co/v1/pdf/find"
 
         ' Prepare requests params as JSON

--- a/Add Text And Images To PDF/VB.NET/Add Text by finding target coordinates/README.md
+++ b/Add Text And Images To PDF/VB.NET/Add Text by finding target coordinates/README.md
@@ -208,7 +208,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",
@@ -276,7 +276,7 @@ Module Module1
         webClient.Headers.Add("Content-Type", "application/json")
 
         ' Prepare URL for PDF text search API call.
-        ' See documentation: https://docs.pdf.co/07-pdf-search-text
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-find/basic
         Dim url As String = "https://api.pdf.co/v1/pdf/find"
 
         ' Prepare requests params as JSON

--- a/Add Text And Images To PDF/VB.NET/Add Text to Existing PDF/Module1.vb
+++ b/Add Text And Images To PDF/VB.NET/Add Text to Existing PDF/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -14,7 +14,7 @@ Imports System.Net
 Imports Newtonsoft.Json.Linq
 
 ' Visit Knowledgebase for adding Text Macros to PDF 
-' https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+' https://docs.pdf.co/api-reference/pdf-add#macros
 
 Module Module1
 
@@ -59,7 +59,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Add Text And Images To PDF/VB.NET/Add Text to Existing PDF/README.md
+++ b/Add Text And Images To PDF/VB.NET/Add Text to Existing PDF/README.md
@@ -201,7 +201,7 @@ Module Module1
 		Dim url As String = "https://api.pdf.co/v1/pdf/edit/add"
 
         ' Prepare requests params as JSON
-        ' See documentation: https://docs.pdf.co/04-pdf-add-text-signatures-and-images-to-pdf
+        ' See documentation: https://docs.pdf.co/api-reference/pdf-add
         Dim jsonPayload As String = $"{{
     ""name"": ""{Path.GetFileName(DestinationFile)}"",
     ""url"": ""{SourceFileUrl}"",

--- a/Barcode Generator API/AWS Lambda/Generate Barcode (Node.js)/app.js
+++ b/Barcode Generator API/AWS Lambda/Generate Barcode (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/C#/Generate Barcode/Program.cs
+++ b/Barcode Generator API/C#/Generate Barcode/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/C#/Generate Barcode/Properties/AssemblyInfo.cs
+++ b/Barcode Generator API/C#/Generate Barcode/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/C#/QR Code With Redundancy Setting/Program.cs
+++ b/Barcode Generator API/C#/QR Code With Redundancy Setting/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/C#/QR Code With Redundancy Setting/Properties/AssemblyInfo.cs
+++ b/Barcode Generator API/C#/QR Code With Redundancy Setting/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/Java/Generate Barcode/src/com/company/Main.java
+++ b/Barcode Generator API/Java/Generate Barcode/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/Java/QR Code With Redundancy Setting/src/com/company/Main.java
+++ b/Barcode Generator API/Java/QR Code With Redundancy Setting/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode (JQuery) - Async API/generate_barcode.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode (JQuery) - Async API/generate_barcode.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode (JQuery)/generate_barcode.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode (JQuery)/generate_barcode.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode (Node.js) - Async API/app.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode (Node.js)/app.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode - Async API/generate_barcode.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode - Async API/generate_barcode.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/Generate Barcode/generate_barcode.js
+++ b/Barcode Generator API/JavaScript/Generate Barcode/generate_barcode.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/JavaScript/QR Code With Redundancy Setting/app.js
+++ b/Barcode Generator API/JavaScript/QR Code With Redundancy Setting/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Generator API/VB.NET/Generate Barcode/Module1.vb
+++ b/Barcode Generator API/VB.NET/Generate Barcode/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Generator API/VB.NET/Generate Barcode/My Project/AssemblyInfo.vb
+++ b/Barcode Generator API/VB.NET/Generate Barcode/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Generator API/VB.NET/QR Code With Redundancy Setting/Module1.vb
+++ b/Barcode Generator API/VB.NET/QR Code With Redundancy Setting/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Generator API/VB.NET/QR Code With Redundancy Setting/My Project/AssemblyInfo.vb
+++ b/Barcode Generator API/VB.NET/QR Code With Redundancy Setting/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/AWS Lambda/Read Barcode From URL (Node.js)/app.js
+++ b/Barcode Reader API/AWS Lambda/Read Barcode From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Advanced Conversion Options/Program.cs
+++ b/Barcode Reader API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Async File Uploading/Program.cs
+++ b/Barcode Reader API/C#/Async File Uploading/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Async File Uploading/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Async File Uploading/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Async file upload and async barcode reading/Program.cs
+++ b/Barcode Reader API/C#/Async file upload and async barcode reading/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Async file upload and async barcode reading/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Async file upload and async barcode reading/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From Encrypted URL/Program.cs
+++ b/Barcode Reader API/C#/Read Barcode From Encrypted URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -32,7 +32,7 @@ namespace ByteScoutWebApiExample
         // See valid barcode types in the documentation https://docs.pdf.co
         const string BarcodeTypes = "QRCode";
         
-        // Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+        // Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
         const string Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }";
 
 

--- a/Barcode Reader API/C#/Read Barcode From Encrypted URL/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read Barcode From Encrypted URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From URL Asynchronously/Program.cs
+++ b/Barcode Reader API/C#/Read Barcode From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read Barcode From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From URL/Program.cs
+++ b/Barcode Reader API/C#/Read Barcode From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From URL/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read Barcode From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From Uploaded File/Program.cs
+++ b/Barcode Reader API/C#/Read Barcode From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Barcode From Uploaded File/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read Barcode From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Code 128/Program.cs
+++ b/Barcode Reader API/C#/Read Code 128/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read Code 128/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read Code 128/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read EAN 13/Program.cs
+++ b/Barcode Reader API/C#/Read EAN 13/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read EAN 13/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read EAN 13/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read QR Code/Program.cs
+++ b/Barcode Reader API/C#/Read QR Code/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/C#/Read QR Code/Properties/AssemblyInfo.cs
+++ b/Barcode Reader API/C#/Read QR Code/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/Extract PDF417 Barcode Data and Send to Google Sheets/code.js
+++ b/Barcode Reader API/Extract PDF417 Barcode Data and Send to Google Sheets/code.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/GoogleAppScript/Read QR Code From PDF/program.js
+++ b/Barcode Reader API/GoogleAppScript/Read QR Code From PDF/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/Java/Advanced Conversation Options/src/com/company/Main.java
+++ b/Barcode Reader API/Java/Advanced Conversation Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/Java/Read Barcode From Encrypted URL/src/com/company/Main.java
+++ b/Barcode Reader API/Java/Read Barcode From Encrypted URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -33,7 +33,7 @@ public class Main
     // See valid barcode types in the documentation https://docs.pdf.co
     final static String BarcodeTypes = "QRCode";
 
-    // Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+    // Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
     final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }";
 
 

--- a/Barcode Reader API/Java/Read Barcode From URL/src/com/company/Main.java
+++ b/Barcode Reader API/Java/Read Barcode From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/Java/Read Barcode From Uploaded File/src/com/company/Main.java
+++ b/Barcode Reader API/Java/Read Barcode From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Advanced Conversion Options/app.js
+++ b/Barcode Reader API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From Encrypted URL/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From Encrypted URL/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -24,7 +24,7 @@ const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/de
 // See valid barcode types in the documentation https://docs.pdf.co
 const BarcodeTypes = "QRCode";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }";
 
 // Prepare request to `Barcode Reader` API endpoint

--- a/Barcode Reader API/JavaScript/Read Barcode From File (Node.js) - Async Api/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From File (Node.js) - Async Api/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From Live Camera/Scripts/index.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From Live Camera/Scripts/index.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From Live Camera/Scripts/webcam.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From Live Camera/Scripts/webcam.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From URL (Node.js) - Async API/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From URL (Node.js)/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From Uploaded File (Node.js) - Async Api/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From Uploaded File (Node.js) - Async Api/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/JavaScript/Read Barcode From Uploaded File (Node.js)/app.js
+++ b/Barcode Reader API/JavaScript/Read Barcode From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Barcode Reader API/PHP/Read Barcode From Encrypted URL Asynchronously/read-barcode-async.php
+++ b/Barcode Reader API/PHP/Read Barcode From Encrypted URL Asynchronously/read-barcode-async.php
@@ -24,7 +24,7 @@ $sourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fi
 // See valid barcode types in the documentation https://docs.pdf.co
 $barcodeTypes = "QRCode";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }";
 
 

--- a/Barcode Reader API/PowerShell/Read Barcode From Encrypted URL/ReadBarcodeFromURL.ps1
+++ b/Barcode Reader API/PowerShell/Read Barcode From Encrypted URL/ReadBarcodeFromURL.ps1
@@ -9,7 +9,7 @@ $SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fi
 # See valid barcode types in the documentation https://docs.pdf.co
 $BarcodeTypes = "QRCode"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }"
 
 # Prepare URL for `Barcode Reader` API call

--- a/Barcode Reader API/Python/Read Barcode From Encrypted URL/ReadBarcodeFromUrl.py
+++ b/Barcode Reader API/Python/Read Barcode From Encrypted URL/ReadBarcodeFromUrl.py
@@ -16,7 +16,7 @@ SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fil
 # See valid barcode types in the documentation https://docs.pdf.co
 BarcodeTypes = "QRCode"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }"
 
 

--- a/Barcode Reader API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/Barcode Reader API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Async File Upload and Async Barcode Reading/Module1.vb
+++ b/Barcode Reader API/VB.NET/Async File Upload and Async Barcode Reading/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Async File Upload and Async Barcode Reading/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Async File Upload and Async Barcode Reading/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Async File Uploading/Module1.vb
+++ b/Barcode Reader API/VB.NET/Async File Uploading/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Async File Uploading/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Async File Uploading/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From Encrypted URL/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From Encrypted URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -28,7 +28,7 @@ Module Module1
 	' See valid barcode types in the documentation https://docs.pdf.co
 	Const BarcodeTypes As String = "QRCode"
 
-	' Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption.
+	' Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption.
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'Qweasd1234567890', 'DataDecryptionIV': '0mDI&qLv*ivTCd$*' }"
 
 	Sub Main()

--- a/Barcode Reader API/VB.NET/Read Barcode From Encrypted URL/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From Encrypted URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From URL Asynchronously/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From URL/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From URL/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From Uploaded File/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Barcode From Uploaded File/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read Barcode From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Code 128/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read Code 128/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read Code 128/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read Code 128/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read EAN 13/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read EAN 13/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read EAN 13/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read EAN 13/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read QR Code/Module1.vb
+++ b/Barcode Reader API/VB.NET/Read QR Code/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Barcode Reader API/VB.NET/Read QR Code/My Project/AssemblyInfo.vb
+++ b/Barcode Reader API/VB.NET/Read QR Code/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/AWS Lambda/Convert DOC To PDF From URL (Node.js)/app.js
+++ b/DOC To PDF API/AWS Lambda/Convert DOC To PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From URL Asynchronously/Program.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From URL/Program.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From URL/Properties/AssemblyInfo.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From Uploaded File/Program.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert DOC To PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/DOC To PDF API/C#/Convert DOC To PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/C#/Convert Encrypted DOC To PDF From URL/Program.cs
+++ b/DOC To PDF API/C#/Convert Encrypted DOC To PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -28,7 +28,7 @@ namespace ByteScoutWebApiExample
         // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/
 		const string SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx";
 
-		// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+		// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 		const string Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 		// Destination PDF file name

--- a/DOC To PDF API/C#/Convert Encrypted DOC To PDF From URL/Properties/AssemblyInfo.cs
+++ b/DOC To PDF API/C#/Convert Encrypted DOC To PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/Java/Convert DOC To PDF From URL/src/com/company/Main.java
+++ b/DOC To PDF API/Java/Convert DOC To PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/Java/Convert DOC To PDF From Uploaded File/src/com/company/Main.java
+++ b/DOC To PDF API/Java/Convert DOC To PDF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/Java/Convert Encrypted DOC To PDF From URL/src/com/company/Main.java
+++ b/DOC To PDF API/Java/Convert Encrypted DOC To PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -30,7 +30,7 @@ public class Main
     // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 	final static String SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx";
 
-    // Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+    // Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
     // Destination PDF file name

--- a/DOC To PDF API/JavaScript/Convert DOC To PDF From Base64 (Node.js)/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To PDF From Base64 (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To PDF From URL (Node.js) - Async API/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To PDF From URL (Node.js)/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To PDF From Uploaded File (Node.js)/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To Protected PDF From URL (Node.js) - Async API/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To Protected PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert DOC To Protected PDF From URL (Node.js)/app.js
+++ b/DOC To PDF API/JavaScript/Convert DOC To Protected PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/DOC To PDF API/JavaScript/Convert Encrypted DOC To PDF From URL (Node.js) - Async API/app.js
+++ b/DOC To PDF API/JavaScript/Convert Encrypted DOC To PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -23,7 +23,7 @@ const API_KEY = "*********************************";
 // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Destination PDF file name

--- a/DOC To PDF API/PHP/Convert Encrypted DOC To PDF Asynchronously/doc-to-pdf-async.php
+++ b/DOC To PDF API/PHP/Convert Encrypted DOC To PDF Asynchronously/doc-to-pdf-async.php
@@ -20,7 +20,7 @@ $apiKey = "***********************************";
 // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 $sourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Prepare URL for `DOC To PDF` API call

--- a/DOC To PDF API/PowerShell/Convert Encrypted DOC To PDF From URL Asynchronously/ConvertDocToPdfFromUrlAsynchronously.ps1
+++ b/DOC To PDF API/PowerShell/Convert Encrypted DOC To PDF From URL Asynchronously/ConvertDocToPdfFromUrlAsynchronously.ps1
@@ -8,7 +8,7 @@ $API_KEY = "***********************************"
 # Direct URL of source DOC or DOCX file.
 $SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 # Destination PDF file name

--- a/DOC To PDF API/Python/Convert Encrypted DOC To PDF From URL Asynchronously/ConvertDocToPdfFromUrlAsynchronously.py
+++ b/DOC To PDF API/Python/Convert Encrypted DOC To PDF From URL Asynchronously/ConvertDocToPdfFromUrlAsynchronously.py
@@ -17,7 +17,7 @@ BASE_URL = "https://api.pdf.co/v1"
 # You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 # Destination PDF file name

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From URL Asynchronously/Module1.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From URL/Module1.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From URL/My Project/AssemblyInfo.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From Uploaded File/Module1.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert DOC To PDF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/DOC To PDF API/VB.NET/Convert DOC To PDF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/DOC To PDF API/VB.NET/Convert Encrypted DOC To PDF From URL Asynchronously/Module1.vb
+++ b/DOC To PDF API/VB.NET/Convert Encrypted DOC To PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -28,7 +28,7 @@ Module Module1
     ' You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/   
 	Const SourceFileUrl As String = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.docx"
 
-	' Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	' Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 	' Destination PDF file name

--- a/DOC To PDF API/VB.NET/Convert Encrypted DOC To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/DOC To PDF API/VB.NET/Convert Encrypted DOC To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/AWS Lambda/Delete PDF Text From URL (Node.js)/app.js
+++ b/Delete Text From PDF/AWS Lambda/Delete PDF Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From URL Asynchronously/Program.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From URL/Program.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From URL/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From Uploaded File/Program.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Delete PDF Text From Uploaded File/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Delete PDF Text From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove And Blackout Credit Card Data From PDF/Program.cs
+++ b/Delete Text From PDF/C#/Remove And Blackout Credit Card Data From PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove And Blackout Credit Card Data From PDF/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Remove And Blackout Credit Card Data From PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove And Blackout Email and SSN Data From PDF/Program.cs
+++ b/Delete Text From PDF/C#/Remove And Blackout Email and SSN Data From PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove And Blackout Email and SSN Data From PDF/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Remove And Blackout Email and SSN Data From PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove Credit Card Data From PDF/Program.cs
+++ b/Delete Text From PDF/C#/Remove Credit Card Data From PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove Credit Card Data From PDF/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Remove Credit Card Data From PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove Email and SSN Data From PDF/Program.cs
+++ b/Delete Text From PDF/C#/Remove Email and SSN Data From PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/C#/Remove Email and SSN Data From PDF/Properties/AssemblyInfo.cs
+++ b/Delete Text From PDF/C#/Remove Email and SSN Data From PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/Java/Delete PDF Text From URL/src/com/company/Main.java
+++ b/Delete Text From PDF/Java/Delete PDF Text From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/Java/Delete PDF Text From Uploaded File/src/com/company/Main.java
+++ b/Delete Text From PDF/Java/Delete PDF Text From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Delete PDF Text From URL (Node.js) - Async API/app.js
+++ b/Delete Text From PDF/JavaScript/Delete PDF Text From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Delete PDF Text From URL (Node.js)/app.js
+++ b/Delete Text From PDF/JavaScript/Delete PDF Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Delete PDF Text From Uploaded File (Node.js) - Async API/app.js
+++ b/Delete Text From PDF/JavaScript/Delete PDF Text From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Delete PDF Text From Uploaded File (Node.js)/app.js
+++ b/Delete Text From PDF/JavaScript/Delete PDF Text From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Remove Credit Card Data From PDF/app.js
+++ b/Delete Text From PDF/JavaScript/Remove Credit Card Data From PDF/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Remove Email and SSN Data From PDF/app.js
+++ b/Delete Text From PDF/JavaScript/Remove Email and SSN Data From PDF/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/JavaScript/Remove PII Data From PDF/app.js
+++ b/Delete Text From PDF/JavaScript/Remove PII Data From PDF/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From URL Asynchronously/Module1.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From URL/Module1.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From URL/My Project/AssemblyInfo.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From Uploaded File/Module1.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/VB.NET/Delete PDF Text From Uploaded File/My Project/AssemblyInfo.vb
+++ b/Delete Text From PDF/VB.NET/Delete PDF Text From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Delete Text From PDF/n8n/Consolidated Invoice Distribution Workflow/code.js
+++ b/Delete Text From PDF/n8n/Consolidated Invoice Distribution Workflow/code.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Blood Test Results to JSON/Program.cs
+++ b/Document Parser API/C#/Blood Test Results to JSON/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Census table from life and annuity quote request pdf/Program.cs
+++ b/Document Parser API/C#/Census table from life and annuity quote request pdf/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Create Custom Template/Program.cs
+++ b/Document Parser API/C#/Create Custom Template/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Extract line items from tables on multiple pages/Program.cs
+++ b/Document Parser API/C#/Extract line items from tables on multiple pages/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse From URL Asynchronously/Program.cs
+++ b/Document Parser API/C#/Parse From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse From URL/Program.cs
+++ b/Document Parser API/C#/Parse From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse Multipage Table/Program.cs
+++ b/Document Parser API/C#/Parse Multipage Table/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse Simple Document/Program.cs
+++ b/Document Parser API/C#/Parse Simple Document/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse Uploaded File Asynchronously (Using TemplateId)/Program.cs
+++ b/Document Parser API/C#/Parse Uploaded File Asynchronously (Using TemplateId)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse Uploaded File Asynchronously/Program.cs
+++ b/Document Parser API/C#/Parse Uploaded File Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse Uploaded File/Program.cs
+++ b/Document Parser API/C#/Parse Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/HL7Helper.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/HL7Helper.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/JsonHL7Fields.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/JsonHL7Fields.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/JsonParserHelper.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/JsonParserHelper.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Program.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/Component.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/Component.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/Encoding.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/Encoding.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/Field.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/Field.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/HL7Exception.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/HL7Exception.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/Message.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/Message.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/MessageElement.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/MessageElement.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/MessageHelper.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/MessageHelper.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/Segment.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/Segment.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse and Generate HL7 Output/Src/SubComponent.cs
+++ b/Document Parser API/C#/Parse and Generate HL7 Output/Src/SubComponent.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parse with OCR/Program.cs
+++ b/Document Parser API/C#/Parse with OCR/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/C#/Parsing and reading data from Airline Tickets/Program.cs
+++ b/Document Parser API/C#/Parsing and reading data from Airline Tickets/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Blood Test Results to JSON/src/com/company/Main.java
+++ b/Document Parser API/Java/Blood Test Results to JSON/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Create Custom Template/src/com/company/Main.java
+++ b/Document Parser API/Java/Create Custom Template/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/com/company/Main.java
+++ b/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/Document Parser API/Java/Extract Borderless Table to CSV using Template ID Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/com/company/Main.java
+++ b/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/Document Parser API/Java/Extract Multipage PDF Table to CSV Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Extract line items from tables on multiple pages/src/com/company/Main.java
+++ b/Document Parser API/Java/Extract line items from tables on multiple pages/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse From URL Asynchronously/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse From URL Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse From Url/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse From Url/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse Multipage Table/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse Multipage Table/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse Simple Document/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse Simple Document/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse Uploaded File Asynchronously/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse Uploaded File Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse Uploaded File/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parse with OCR/src/com/company/Main.java
+++ b/Document Parser API/Java/Parse with OCR/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/Java/Parsing and reading data from Airline Tickets/src/com/company/Main.java
+++ b/Document Parser API/Java/Parsing and reading data from Airline Tickets/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/JavaScript/Parse From Url (Node.js)/app.js
+++ b/Document Parser API/JavaScript/Parse From Url (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/JavaScript/Parse Uploaded File (Node.js)/app.js
+++ b/Document Parser API/JavaScript/Parse Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/README.md
+++ b/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/README.md
@@ -211,7 +211,7 @@ or just send email to [support@pdf.co](mailto:support@pdf.co?subject=PDF.co%20We
 <?php 
 
 // Get submitted form data
-$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://docs.pdf.co/api
+$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://app.pdf.co
 
 
 // 1. RETRIEVE THE PRESIGNED URL TO UPLOAD THE FILE.

--- a/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/program.html
+++ b/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/program.html
@@ -9,7 +9,7 @@
 
     <form name="form1" enctype="multipart/form-data" method="post" action="program.php">
         <p>
-            <label>Authentication key (API Key). Get your own by registering at <a href="https://docs.pdf.co/api">https://docs.pdf.co/api</a>.</label>
+            <label>Authentication key (API Key). Get your own by registering at <a href="https://app.pdf.co">https://app.pdf.co</a>.</label>
             <br/>
             <input type="text" name="apiKey" placeholder="API Key"/>
         </p>

--- a/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/program.php
+++ b/Document Parser API/PHP/Parse Invoice and Fill Database (SQL Server)/program.php
@@ -9,7 +9,7 @@
 <?php 
 
 // Get submitted form data
-$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://docs.pdf.co/api
+$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://app.pdf.co
 
 
 // 1. RETRIEVE THE PRESIGNED URL TO UPLOAD THE FILE.

--- a/Document Parser API/PHP/Parse Invoice and Save Table Data to mySql Database/program.html
+++ b/Document Parser API/PHP/Parse Invoice and Save Table Data to mySql Database/program.html
@@ -9,7 +9,7 @@
 
     <form name="form1" enctype="multipart/form-data" method="post" action="program.php">
         <p>
-            <label>Authentication key (API Key). Get your own by registering at <a href="https://docs.pdf.co/api">https://docs.pdf.co/api</a>.</label>
+            <label>Authentication key (API Key). Get your own by registering at <a href="https://app.pdf.co">https://app.pdf.co</a>.</label>
             <br/>
             <input type="text" name="apiKey" placeholder="API Key"/>
         </p>

--- a/Document Parser API/PHP/Parse Invoice and Save Table Data to mySql Database/program.php
+++ b/Document Parser API/PHP/Parse Invoice and Save Table Data to mySql Database/program.php
@@ -9,7 +9,7 @@
 <?php 
 
 // Get submitted form data
-$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://docs.pdf.co/api
+$apiKey = $_POST["apiKey"]; // The authentication key (API Key). Get your own by registering at https://app.pdf.co
 
 
 // 1. RETRIEVE THE PRESIGNED URL TO UPLOAD THE FILE.

--- a/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/Utils.cs
+++ b/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/Utils.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/VisualWebPart1.cs
+++ b/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/VisualWebPart1.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
+++ b/Document Parser API/SharePoint/Parse Invoice Information/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Document Parser API/VB.NET/Blood Test Results to JSON/Module1.vb
+++ b/Document Parser API/VB.NET/Blood Test Results to JSON/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Census table from life and annuity quote request pdf/Module1.vb
+++ b/Document Parser API/VB.NET/Census table from life and annuity quote request pdf/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Create Custom Template/Module1.vb
+++ b/Document Parser API/VB.NET/Create Custom Template/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Extract line items from tables on multiple pages/Module1.vb
+++ b/Document Parser API/VB.NET/Extract line items from tables on multiple pages/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse From Url/Module1.vb
+++ b/Document Parser API/VB.NET/Parse From Url/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse Multipage Table/Module1.vb
+++ b/Document Parser API/VB.NET/Parse Multipage Table/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse Simple Document/Module1.vb
+++ b/Document Parser API/VB.NET/Parse Simple Document/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse Uploaded File Asynchronously/Module1.vb
+++ b/Document Parser API/VB.NET/Parse Uploaded File Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse Uploaded File/Module1.vb
+++ b/Document Parser API/VB.NET/Parse Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parse with OCR/Module1.vb
+++ b/Document Parser API/VB.NET/Parse with OCR/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/VB.NET/Parsing and reading data from Airline Tickets/Module1.vb
+++ b/Document Parser API/VB.NET/Parsing and reading data from Airline Tickets/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Document Parser API/n8n/Automatically Extract Invoice Data from Email and Save to Google Sheets/code_sample.js
+++ b/Document Parser API/n8n/Automatically Extract Invoice Data from Email and Save to Google Sheets/code_sample.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/C#/Email to PDF From URL/Program.cs
+++ b/Email Extractor/Email to PDF/C#/Email to PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/C#/Email to PDF From Uploaded File/Program.cs
+++ b/Email Extractor/Email to PDF/C#/Email to PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/C#/Email to PDF With Custom Orientation and Paper Size/Program.cs
+++ b/Email Extractor/Email to PDF/C#/Email to PDF With Custom Orientation and Paper Size/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/Java/Email to PDF With Custom Orientation and Paper Size/Program.java
+++ b/Email Extractor/Email to PDF/Java/Email to PDF With Custom Orientation and Paper Size/Program.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/Java/Email to PDF/EmailToPDF.java
+++ b/Email Extractor/Email to PDF/Java/Email to PDF/EmailToPDF.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/JavaScript/Email to PDF With Custom Orientation and Paper Size/Program.js
+++ b/Email Extractor/Email to PDF/JavaScript/Email to PDF With Custom Orientation and Paper Size/Program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/JavaScript/Email to PDF/EmailToPDF.js
+++ b/Email Extractor/Email to PDF/JavaScript/Email to PDF/EmailToPDF.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Extractor/Email to PDF/VB.NET/Email to PDF From URL/Module1.vb
+++ b/Email Extractor/Email to PDF/VB.NET/Email to PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Email Extractor/Email to PDF/VB.NET/Email to PDF From Uploaded File/Module1.vb
+++ b/Email Extractor/Email to PDF/VB.NET/Email to PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Email Extractor/Email to PDF/VB.NET/Email to PDF With Custom Orientation and Paper Size/Program.vb
+++ b/Email Extractor/Email to PDF/VB.NET/Email to PDF With Custom Orientation and Paper Size/Program.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Email Send and Decode/C#/Extract Email Attachments/GetEmailAttachmentInfo.cs
+++ b/Email Send and Decode/C#/Extract Email Attachments/GetEmailAttachmentInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/C#/Get Email Information/GetEmailInfo.cs
+++ b/Email Send and Decode/C#/Get Email Information/GetEmailInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/C#/Send Email/Program.cs
+++ b/Email Send and Decode/C#/Send Email/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -27,7 +27,7 @@ namespace ByteScoutWebApiExample
 		const string SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/pdf-info/sample.pdf";
 
 		// Email Details
-		// Please refer to our knowledge base at (https://docs.pdf.co/kb/Email%20Send%20(email-send)/index) for SMTP related information
+		// Please refer to our knowledge base at (https://docs.pdf.co/api-reference/email/send#send-email-with-file) for SMTP related information
 		const string From = "John Doe <john@example.com>";
 		const string To = "Partner <partner@example.com>";
 		const string Subject = "Check attached sample pdf";

--- a/Email Send and Decode/C#/Send Email/Properties/AssemblyInfo.cs
+++ b/Email Send and Decode/C#/Send Email/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/Java/Extract Email Attachments/GetEmailAttachmentInfo.java
+++ b/Email Send and Decode/Java/Extract Email Attachments/GetEmailAttachmentInfo.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/Java/Get Email Information/GetEmailInfo.java
+++ b/Email Send and Decode/Java/Get Email Information/GetEmailInfo.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/JavaScript/Extract Email Attachments/GetEmailAttachmentInfo.js
+++ b/Email Send and Decode/JavaScript/Extract Email Attachments/GetEmailAttachmentInfo.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/JavaScript/Get Email Information/GetEmailInfo.js
+++ b/Email Send and Decode/JavaScript/Get Email Information/GetEmailInfo.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Email Send and Decode/JavaScript/Send Email/program.js
+++ b/Email Send and Decode/JavaScript/Send Email/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -9,7 +9,7 @@
 //*******************************************************************************************//
 
 
-// Please refer to our knowledge base at (https://docs.pdf.co/kb/Email%20Send%20(email-send)/index) for SMTP related information
+// Please refer to our knowledge base at (https://docs.pdf.co/api-reference/email/send#send-email-with-file) for SMTP related information
 
 var request = require('request');
 var options = {

--- a/Email Send and Decode/PHP/Send Email/sample.php
+++ b/Email Send and Decode/PHP/Send Email/sample.php
@@ -1,6 +1,6 @@
 <?php
 
-// Please refer to our knowledge base at (https://docs.pdf.co/kb/Email%20Send%20(email-send)/index) for SMTP related information
+// Please refer to our knowledge base at (https://docs.pdf.co/api-reference/email/send#send-email-with-file) for SMTP related information
 
 $curl = curl_init();
 

--- a/Email Send and Decode/PowerShell/Send Email/program.ps1
+++ b/Email Send and Decode/PowerShell/Send Email/program.ps1
@@ -1,4 +1,4 @@
-# Please refer to our knowledge base at (https://docs.pdf.co/kb/Email%20Send%20(email-send)/index) for SMTP related information
+# Please refer to our knowledge base at (https://docs.pdf.co/api-reference/email/send#send-email-with-file) for SMTP related information
 
 
 $headers = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"

--- a/Email Send and Decode/Python/Send Email/sample.py
+++ b/Email Send and Decode/Python/Send Email/sample.py
@@ -3,7 +3,7 @@ import json
 
 url = "https://api.pdf.co/v1/email/send"
 
-# Please refer to our knowledge base at (https://docs.pdf.co/kb/Email%20Send%20(email-send)/index) for SMTP related information
+# Please refer to our knowledge base at (https://docs.pdf.co/api-reference/email/send#send-email-with-file) for SMTP related information
 
 payload = json.dumps({
   "url": "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/pdf-info/sample.pdf",

--- a/Excel To CSV API/JavaScript/Convert Excel to CSV in jQuery - Async API/converter.js
+++ b/Excel To CSV API/JavaScript/Convert Excel to CSV in jQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Excel To CSV API/JavaScript/Convert Excel to CSV in jQuery/converter.js
+++ b/Excel To CSV API/JavaScript/Convert Excel to CSV in jQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Excel To HTML API/JavaScript/Convert Excel to HTML jQuery - Async API/converter.js
+++ b/Excel To HTML API/JavaScript/Convert Excel to HTML jQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Excel To HTML API/JavaScript/Convert Excel to HTML jQuery/converter.js
+++ b/Excel To HTML API/JavaScript/Convert Excel to HTML jQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Excel To JSON API/JavaScript/Convert Excel to JSON in jQuery - Async API/converter.js
+++ b/Excel To JSON API/JavaScript/Convert Excel to JSON in jQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Excel To JSON API/JavaScript/Convert Excel to JSON in jQuery/converter.js
+++ b/Excel To JSON API/JavaScript/Convert Excel to JSON in jQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Calculate Hash/C#/FileCalculateHash.cs
+++ b/File Calculate Hash/C#/FileCalculateHash.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Calculate Hash/Java/FileCalculateHash.java
+++ b/File Calculate Hash/Java/FileCalculateHash.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Calculate Hash/JavaScript/FileCalculateHash.js
+++ b/File Calculate Hash/JavaScript/FileCalculateHash.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Delete/C#/FileDelete.cs
+++ b/File Delete/C#/FileDelete.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Delete/Java/FileDelete.java
+++ b/File Delete/Java/FileDelete.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Delete/JavaScript/FileDelete.js
+++ b/File Delete/JavaScript/FileDelete.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/C#/UploadSmallFileFromBase64.cs
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/C#/UploadSmallFileFromBase64.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/Java/UploadSmallFileFromBase64.java
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/Java/UploadSmallFileFromBase64.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/JavaScript/UploadSmallFileFromBase64.js
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Base64/JavaScript/UploadSmallFileFromBase64.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Url/C#/UploadSmallFileFromUrl.cs
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Url/C#/UploadSmallFileFromUrl.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Url/Java/UploadSmallFileFromUrl.java
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Url/Java/UploadSmallFileFromUrl.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File from Url/JavaScript/UploadSmallFileFromUrl.js
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File from Url/JavaScript/UploadSmallFileFromUrl.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File/C#/UploadSmallFile.cs
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File/C#/UploadSmallFile.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File/Java/UploadSmallFile.java
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File/Java/UploadSmallFile.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload for Small Files (up to 50KB)/Upload Small File/JavaScript/UploadSmallFile.js
+++ b/File Upload for Small Files (up to 50KB)/Upload Small File/JavaScript/UploadSmallFile.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Generate Secure URL for Upload/C#/GenerateSecureUrlForUpload.cs
+++ b/File Upload/Generate Secure URL for Upload/C#/GenerateSecureUrlForUpload.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Generate Secure URL for Upload/Java/GenerateSecureUrlForUpload.java
+++ b/File Upload/Generate Secure URL for Upload/Java/GenerateSecureUrlForUpload.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Generate Secure URL for Upload/JavaScript/GenerateSecureUrlForUpload.js
+++ b/File Upload/Generate Secure URL for Upload/JavaScript/GenerateSecureUrlForUpload.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Put Upload File/C#/Get Uploaded File URL/Program.cs
+++ b/File Upload/Put Upload File/C#/Get Uploaded File URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Put Upload File/C#/Get Uploaded File URL/Properties/AssemblyInfo.cs
+++ b/File Upload/Put Upload File/C#/Get Uploaded File URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Put Upload File/Java/Get Uploaded File URL/src/com/company/Main.java
+++ b/File Upload/Put Upload File/Java/Get Uploaded File URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Put Upload File/JavaScript/Get Uploaded File URL/app.js
+++ b/File Upload/Put Upload File/JavaScript/Get Uploaded File URL/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/File Upload/Put Upload File/VB.NET/Get Uploaded File URL/Module1.vb
+++ b/File Upload/Put Upload File/VB.NET/Get Uploaded File URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/File Upload/Put Upload File/VB.NET/Get Uploaded File URL/My Project/AssemblyInfo.vb
+++ b/File Upload/Put Upload File/VB.NET/Get Uploaded File URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/AWS Lambda/Convert Images To PDF From URLs (Node.js)/app.js
+++ b/Image To PDF API/AWS Lambda/Convert Images To PDF From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From URLs Asynchronously/Program.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From URLs Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From URLs Asynchronously/Properties/AssemblyInfo.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From URLs Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From URLs/Program.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From URLs/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From URLs/Properties/AssemblyInfo.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From URLs/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From Uploaded Files/Program.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From Uploaded Files/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/C#/Convert Images To PDF From Uploaded Files/Properties/AssemblyInfo.cs
+++ b/Image To PDF API/C#/Convert Images To PDF From Uploaded Files/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/Java/Convert Images To PDF From URLs/src/com/company/Main.java
+++ b/Image To PDF API/Java/Convert Images To PDF From URLs/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/Java/Convert Images To PDF From Uploaded Files/src/com/company/Main.java
+++ b/Image To PDF API/Java/Convert Images To PDF From Uploaded Files/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/JavaScript/Convert Image to PDF from Base64 Asynchronously/app.js
+++ b/Image To PDF API/JavaScript/Convert Image to PDF from Base64 Asynchronously/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/JavaScript/Convert Images To PDF From URLs (Node.js) - Async API/app.js
+++ b/Image To PDF API/JavaScript/Convert Images To PDF From URLs (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/JavaScript/Convert Images To PDF From URLs (Node.js)/app.js
+++ b/Image To PDF API/JavaScript/Convert Images To PDF From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Image To PDF API/VB.NET/Convert Images To PDF From URLs Asynchronously/Module1.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From URLs Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/VB.NET/Convert Images To PDF From URLs Asynchronously/My Project/AssemblyInfo.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From URLs Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/VB.NET/Convert Images To PDF From URLs/Module1.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From URLs/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/VB.NET/Convert Images To PDF From URLs/My Project/AssemblyInfo.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From URLs/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/VB.NET/Convert Images To PDF From Uploaded Files/Module1.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From Uploaded Files/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Image To PDF API/VB.NET/Convert Images To PDF From Uploaded Files/My Project/AssemblyInfo.vb
+++ b/Image To PDF API/VB.NET/Convert Images To PDF From Uploaded Files/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Manage Background Jobs/C#/Check Job Status/ManageBackgroundJob.cs
+++ b/Manage Background Jobs/C#/Check Job Status/ManageBackgroundJob.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Manage Background Jobs/Java/Check Job Status/ManageBackgroundJob.java
+++ b/Manage Background Jobs/Java/Check Job Status/ManageBackgroundJob.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Manage Background Jobs/JavaScript/Check Job Status/ManageBackgroundJob.js
+++ b/Manage Background Jobs/JavaScript/Check Job Status/ManageBackgroundJob.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Attachments/AWS Lambda/Extract PDF Attachments From URL (Node.js)/app.js
+++ b/PDF Attachments/AWS Lambda/Extract PDF Attachments From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Attachments/C#/Extract PDF Attachments From URL/Program.cs
+++ b/PDF Attachments/C#/Extract PDF Attachments From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Attachments/Java/Extract PDF Attachments From URL/program.java
+++ b/PDF Attachments/Java/Extract PDF Attachments From URL/program.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Attachments/JavaScript/Extract PDF Attachments From URL (Node.js)/app.js
+++ b/PDF Attachments/JavaScript/Extract PDF Attachments From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Attachments/JavaScript/Extract PDF Attachments From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Attachments/JavaScript/Extract PDF Attachments From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/C#/Classify PDF From URL/program.cs
+++ b/PDF Classifier/C#/Classify PDF From URL/program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/C#/Classify PDF from URL with Custom Rules/program.cs
+++ b/PDF Classifier/C#/Classify PDF from URL with Custom Rules/program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/Java/Classify PDF From URL/program.java
+++ b/PDF Classifier/Java/Classify PDF From URL/program.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/Java/Classify PDF from URL with Custom Rules/program.java
+++ b/PDF Classifier/Java/Classify PDF from URL with Custom Rules/program.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/JavaScript/Classify PDF From URL (jQuery)/program.js
+++ b/PDF Classifier/JavaScript/Classify PDF From URL (jQuery)/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/JavaScript/Classify PDF From URL (nodeJs)/program.js
+++ b/PDF Classifier/JavaScript/Classify PDF From URL (nodeJs)/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/JavaScript/Classify PDF from URL with Custom Rules (jQuery)/program.js
+++ b/PDF Classifier/JavaScript/Classify PDF from URL with Custom Rules (jQuery)/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Classifier/JavaScript/Classify PDF from URL with Custom Rules (nodeJs)/program.js
+++ b/PDF Classifier/JavaScript/Classify PDF from URL with Custom Rules (nodeJs)/program.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Create Fillable PDF Forms/AWS Lambda/Fillable PDF Forms - Node Js/app.js
+++ b/PDF Create Fillable PDF Forms/AWS Lambda/Fillable PDF Forms - Node Js/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Create Fillable PDF Forms/C#/Fillable PDF Forms/Program.cs
+++ b/PDF Create Fillable PDF Forms/C#/Fillable PDF Forms/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Create Fillable PDF Forms/Java/Fillable PDF Forms/src/com/company/Main.java
+++ b/PDF Create Fillable PDF Forms/Java/Fillable PDF Forms/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Create Fillable PDF Forms/JavaScript/Fillable PDF Forms/app.js
+++ b/PDF Create Fillable PDF Forms/JavaScript/Fillable PDF Forms/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Create Fillable PDF Forms/VB.NET/Fillable PDF Forms/Module1.vb
+++ b/PDF Create Fillable PDF Forms/VB.NET/Fillable PDF Forms/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Delete Pages/C#/Delete Pages From PDF/PDFDeletePages.cs
+++ b/PDF Delete Pages/C#/Delete Pages From PDF/PDFDeletePages.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Delete Pages/Java/Delete Pages From PDF/PDFDeletePages.java
+++ b/PDF Delete Pages/Java/Delete Pages From PDF/PDFDeletePages.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Delete Pages/JavaScript/Delete Pages From PDF Asynchronously/app.js
+++ b/PDF Delete Pages/JavaScript/Delete Pages From PDF Asynchronously/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Delete Pages/JavaScript/Delete Pages From PDF/PDFDeletePages.js
+++ b/PDF Delete Pages/JavaScript/Delete Pages From PDF/PDFDeletePages.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/AWS Lambda/Fill PDF Forms NodeJs/app.js
+++ b/PDF Fill PDF Forms/AWS Lambda/Fill PDF Forms NodeJs/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/AWS Lambda/Fill PDF Forms Simplified NodeJs/app.js
+++ b/PDF Fill PDF Forms/AWS Lambda/Fill PDF Forms Simplified NodeJs/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/C#/Fill PDF Forms Asynchronously/Program.cs
+++ b/PDF Fill PDF Forms/C#/Fill PDF Forms Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/C#/Fill PDF Forms Simplified Asynchronously/Program.cs
+++ b/PDF Fill PDF Forms/C#/Fill PDF Forms Simplified Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/C#/Fill PDF Forms Simplified/Program.cs
+++ b/PDF Fill PDF Forms/C#/Fill PDF Forms Simplified/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/C#/Fill PDF Forms/Program.cs
+++ b/PDF Fill PDF Forms/C#/Fill PDF Forms/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/GoogleAppScript/program.gs
+++ b/PDF Fill PDF Forms/GoogleAppScript/program.gs
@@ -1,5 +1,5 @@
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // Handle PDF.co Menu on Google Sheet Open Event
 function onOpen() {

--- a/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/com/company/Main.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/target/classes/archetype-resources/src/main/java/App.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/target/classes/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Form Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Forms Simplified/src/com/company/Main.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Forms Simplified/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/Java/Fill PDF Forms/src/com/company/Main.java
+++ b/PDF Fill PDF Forms/Java/Fill PDF Forms/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/JavaScript/Fill PDF Forms Simplified/app.js
+++ b/PDF Fill PDF Forms/JavaScript/Fill PDF Forms Simplified/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/JavaScript/Fill PDF Forms/app.js
+++ b/PDF Fill PDF Forms/JavaScript/Fill PDF Forms/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Fill PDF Forms/VB.NET/Fill PDF Forms Simplified/Module1.vb
+++ b/PDF Fill PDF Forms/VB.NET/Fill PDF Forms Simplified/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Fill PDF Forms/VB.NET/Fill PDF Forms/Module1.vb
+++ b/PDF Fill PDF Forms/VB.NET/Fill PDF Forms/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Forms Info Reader/C#/Read PDF Form Information/PDFFormInfoReader.cs
+++ b/PDF Forms Info Reader/C#/Read PDF Form Information/PDFFormInfoReader.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Forms Info Reader/Java/Read PDF Form Information/PDFFormInfoReader.java
+++ b/PDF Forms Info Reader/Java/Read PDF Form Information/PDFFormInfoReader.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Forms Info Reader/JavaScript/Read PDF Form Information/PDFFormInfoReader.js
+++ b/PDF Forms Info Reader/JavaScript/Read PDF Form Information/PDFFormInfoReader.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/AWS Lambda/Convert CSV To PDF From URL (Node.js)/app.js
+++ b/PDF From CSV/AWS Lambda/Convert CSV To PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From URL Asynchronously/Program.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From URL/Program.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From Uploaded File/Program.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/C#/Convert CSV To PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF From CSV/C#/Convert CSV To PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/Java/Convert CSV To PDF From URL/src/com/company/Main.java
+++ b/PDF From CSV/Java/Convert CSV To PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/Java/Convert CSV To PDF From Uploaded File/src/com/company/Main.java
+++ b/PDF From CSV/Java/Convert CSV To PDF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/JavaScript/Convert CSV To PDF From URL (Node.js) - Async API/app.js
+++ b/PDF From CSV/JavaScript/Convert CSV To PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/JavaScript/Convert CSV To PDF From URL (Node.js)/app.js
+++ b/PDF From CSV/JavaScript/Convert CSV To PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/JavaScript/Convert CSV To PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF From CSV/JavaScript/Convert CSV To PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/JavaScript/Convert CSV To PDF From Uploaded File (Node.js)/app.js
+++ b/PDF From CSV/JavaScript/Convert CSV To PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From URL Asynchronously/Module1.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From URL/Module1.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From Uploaded File/Module1.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From CSV/VB.NET/Convert CSV To PDF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF From CSV/VB.NET/Convert CSV To PDF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF From Excel/GoogleAppsScript/program.gs
+++ b/PDF From Excel/GoogleAppsScript/program.gs
@@ -1,5 +1,5 @@
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // Handle PDF.co Menu on Google Sheet Open Event
 function onOpen() {

--- a/PDF From Excel/JavaScript/Convert Excel to PDF in JQuery - Async API/converter.js
+++ b/PDF From Excel/JavaScript/Convert Excel to PDF in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF From Excel/JavaScript/Convert Excel to PDF in JQuery/converter.js
+++ b/PDF From Excel/JavaScript/Convert Excel to PDF in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/AWS Lambda/Get PDF Info From URL (Node.js)/app.js
+++ b/PDF Information API/AWS Lambda/Get PDF Info From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/C#/Get Info From Custom Encrypted PDF URL/Program.cs
+++ b/PDF Information API/C#/Get Info From Custom Encrypted PDF URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -27,7 +27,7 @@ namespace ByteScoutWebApiExample
         // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/
 		const string SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf";
 
-		// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+		// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 		const string Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 	

--- a/PDF Information API/C#/Get Info From Custom Encrypted PDF URL/Properties/AssemblyInfo.cs
+++ b/PDF Information API/C#/Get Info From Custom Encrypted PDF URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/C#/Get PDF Info From URL/Program.cs
+++ b/PDF Information API/C#/Get PDF Info From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/C#/Get PDF Info From URL/Properties/AssemblyInfo.cs
+++ b/PDF Information API/C#/Get PDF Info From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/C#/Get PDF Info From Uploaded File/Program.cs
+++ b/PDF Information API/C#/Get PDF Info From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/C#/Get PDF Info From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Information API/C#/Get PDF Info From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/Java/Get Info From Custom Encrypted PDF URL/src/com/company/Main.java
+++ b/PDF Information API/Java/Get Info From Custom Encrypted PDF URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -30,7 +30,7 @@ public class Main
     // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 	final static String SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf";
 
-	// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
     public static void main(String[] args) throws IOException

--- a/PDF Information API/Java/Get PDF Info From URL/src/com/company/Main.java
+++ b/PDF Information API/Java/Get PDF Info From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/Java/Get PDF Info From Uploaded File/src/com/company/Main.java
+++ b/PDF Information API/Java/Get PDF Info From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/JavaScript/Get Info From Custom Encrypted PDF URL (Node.js)/app.js
+++ b/PDF Information API/JavaScript/Get Info From Custom Encrypted PDF URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -19,7 +19,7 @@ const API_KEY = "***********************************";
 // You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Prepare request to `PDF Info` API endpoint

--- a/PDF Information API/JavaScript/Get PDF Info From URL (Node.js)/app.js
+++ b/PDF Information API/JavaScript/Get PDF Info From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/JavaScript/Get PDF Info From URL Asynchronously/app.js
+++ b/PDF Information API/JavaScript/Get PDF Info From URL Asynchronously/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/JavaScript/Get PDF Info From Uploaded File (Node.js)/app.js
+++ b/PDF Information API/JavaScript/Get PDF Info From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Information API/PowerShell/Get Info From Custom Encrypted PDF URL/GetPdfInfoFromUrl.ps1
+++ b/PDF Information API/PowerShell/Get Info From Custom Encrypted PDF URL/GetPdfInfoFromUrl.ps1
@@ -5,7 +5,7 @@ $API_KEY = "***********************************"
 # Direct URL of PDF file to get information
 $SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 

--- a/PDF Information API/Python/Get Info From Custom Encrypted PDF URL/GetPdfInfoFromUrl.py
+++ b/PDF Information API/Python/Get Info From Custom Encrypted PDF URL/GetPdfInfoFromUrl.py
@@ -12,7 +12,7 @@ BASE_URL = "https://api.pdf.co/v1"
 # You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/    
 SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 

--- a/PDF Information API/VB.NET/Get Info From Custom Encrypted PDF URL/Module1.vb
+++ b/PDF Information API/VB.NET/Get Info From Custom Encrypted PDF URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -24,7 +24,7 @@ Module Module1
     ' You can also upload your own file into PDF.co and use it as url. Check "Upload File" samples for code snippets: https://github.com/bytescout/pdf-co-api-samples/tree/master/File%20Upload/   
 	Const SourceFileURL As String = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 
-	' Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	' Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 	Sub Main()

--- a/PDF Information API/VB.NET/Get Info From Custom Encrypted PDF URL/My Project/AssemblyInfo.vb
+++ b/PDF Information API/VB.NET/Get Info From Custom Encrypted PDF URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Information API/VB.NET/Get PDF Info From URL/Module1.vb
+++ b/PDF Information API/VB.NET/Get PDF Info From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Information API/VB.NET/Get PDF Info From URL/My Project/AssemblyInfo.vb
+++ b/PDF Information API/VB.NET/Get PDF Info From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Information API/VB.NET/Get PDF Info From Uploaded File/Module1.vb
+++ b/PDF Information API/VB.NET/Get PDF Info From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Information API/VB.NET/Get PDF Info From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Information API/VB.NET/Get PDF Info From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/AWS Lambda/Make Searchable PDF From URL (Node.js)/app.js
+++ b/PDF Make Searchable API/AWS Lambda/Make Searchable PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/AWS Lambda/Make UnSearchable PDF From URL (Node.js)/app.js
+++ b/PDF Make Searchable API/AWS Lambda/Make UnSearchable PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Advanced Conversion Options/Program.cs
+++ b/PDF Make Searchable API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From URL Asynchronously/Program.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From URL/Program.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From Uploaded File/Program.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/C#/Make Searchable PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Make Searchable API/C#/Make Searchable PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/Java/Advanced Conversation Options/src/com/company/Main.java
+++ b/PDF Make Searchable API/Java/Advanced Conversation Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/Java/Make Searchable PDF From URL/src/com/company/Main.java
+++ b/PDF Make Searchable API/Java/Make Searchable PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/Java/Make Searchable PDF From Uploaded File/src/com/company/Main.java
+++ b/PDF Make Searchable API/Java/Make Searchable PDF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF Make Searchable API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make Searchable PDF From URL (Node.js) - Async API/app.js
+++ b/PDF Make Searchable API/JavaScript/Make Searchable PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make Searchable PDF From URL (Node.js)/app.js
+++ b/PDF Make Searchable API/JavaScript/Make Searchable PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make Searchable PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Make Searchable API/JavaScript/Make Searchable PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make Searchable PDF From Uploaded File (Node.js)/app.js
+++ b/PDF Make Searchable API/JavaScript/Make Searchable PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From URL (Node.js) - Async API/app.js
+++ b/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From URL (Node.js)/app.js
+++ b/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From Uploaded File (Node.js)/app.js
+++ b/PDF Make Searchable API/JavaScript/Make UnSearchable PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/JavaScript/Make Uploaded PDF Searchable Asynchronously/Make PDF Searchable Asynchronously.js
+++ b/PDF Make Searchable API/JavaScript/Make Uploaded PDF Searchable Asynchronously/Make PDF Searchable Asynchronously.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Make Searchable API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF Make Searchable API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL Asynchronously/Module1.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL/Module1.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From Uploaded File/Module1.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Make Searchable API/VB.NET/Make Searchable PDF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Make Searchable API/VB.NET/Make Searchable PDF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/AWS Lambda/Merge Any Documents From URLs (Node.js)/app.js
+++ b/PDF Merging API/AWS Lambda/Merge Any Documents From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/AWS Lambda/Merge Encoded PDF Documents (Node.js)/app.js
+++ b/PDF Merging API/AWS Lambda/Merge Encoded PDF Documents (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -23,7 +23,7 @@ const SourceFiles = [
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 ];
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Prepare request to `Merge PDF` API endpoint

--- a/PDF Merging API/AWS Lambda/Merge Encoded PDF Documents to Encoded Output (Node.js)/app.js
+++ b/PDF Merging API/AWS Lambda/Merge Encoded PDF Documents to Encoded Output (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -23,7 +23,7 @@ const SourceFiles = [
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 ];
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }";
 
 // Prepare request to `Merge PDF` API endpoint

--- a/PDF Merging API/AWS Lambda/Merge PDF Documents From URLs (Node.js)/app.js
+++ b/PDF Merging API/AWS Lambda/Merge PDF Documents From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Async file upload and async Merge PDF/Program.cs
+++ b/PDF Merging API/C#/Async file upload and async Merge PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Async file upload and async Merge PDF/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Async file upload and async Merge PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Any Documents From URLs Asynchronously/Program.cs
+++ b/PDF Merging API/C#/Merge Any Documents From URLs Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Any Documents From URLs Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge Any Documents From URLs Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Any Documents From URLs/Program.cs
+++ b/PDF Merging API/C#/Merge Any Documents From URLs/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Any Documents From URLs/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge Any Documents From URLs/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Encoded PDF Documents To Encoded Output/Program.cs
+++ b/PDF Merging API/C#/Merge Encoded PDF Documents To Encoded Output/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -30,7 +30,7 @@ namespace ByteScoutWebApiExample
 			"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
 			"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf" };
 
-		// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+		// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 		const string Profiles = @"{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }";
 
 		// Destination PDF file name

--- a/PDF Merging API/C#/Merge Encoded PDF Documents To Encoded Output/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge Encoded PDF Documents To Encoded Output/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge Encoded PDF Documents/Program.cs
+++ b/PDF Merging API/C#/Merge Encoded PDF Documents/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -30,7 +30,7 @@ namespace ByteScoutWebApiExample
 			"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
 			"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf" };
 
-		// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+		// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 		const string Profiles = @"{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 		// Destination PDF file name

--- a/PDF Merging API/C#/Merge Encoded PDF Documents/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge Encoded PDF Documents/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From URLs Asynchronously/Program.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From URLs Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From URLs Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From URLs Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From URLs/Program.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From URLs/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From URLs/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From URLs/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From Uploaded Files/Program.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From Uploaded Files/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/C#/Merge PDF Documents From Uploaded Files/Properties/AssemblyInfo.cs
+++ b/PDF Merging API/C#/Merge PDF Documents From Uploaded Files/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/Java/Merge Any Documents From URLs/src/com/company/Main.java
+++ b/PDF Merging API/Java/Merge Any Documents From URLs/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/Java/Merge Encoded PDF Documents to Encoded Output/src/com/company/Main.java
+++ b/PDF Merging API/Java/Merge Encoded PDF Documents to Encoded Output/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -32,7 +32,7 @@ public class Main
             "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
             "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf" };
 
-    // For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+    // For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
     final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }";
 
     // Destination PDF file name

--- a/PDF Merging API/Java/Merge Encoded PDF Documents/src/com/company/Main.java
+++ b/PDF Merging API/Java/Merge Encoded PDF Documents/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -32,7 +32,7 @@ public class Main
             "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
             "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf" };
 
-    // For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+    // For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
     final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
     // Destination PDF file name

--- a/PDF Merging API/Java/Merge PDF Documents From URLs/src/com/company/Main.java
+++ b/PDF Merging API/Java/Merge PDF Documents From URLs/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/Java/Merge PDF Documents From Uploaded Files/src/com/company/Main.java
+++ b/PDF Merging API/Java/Merge PDF Documents From Uploaded Files/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge Any Documents From URLs (Node.js) - Async API/app.js
+++ b/PDF Merging API/JavaScript/Merge Any Documents From URLs (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge Any Documents From URLs (Node.js)/app.js
+++ b/PDF Merging API/JavaScript/Merge Any Documents From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge Any Documents From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Merging API/JavaScript/Merge Any Documents From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge Encoded PDF Documents (Node.js)/app.js
+++ b/PDF Merging API/JavaScript/Merge Encoded PDF Documents (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -26,7 +26,7 @@ const SourceFiles = [
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 ];
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Destination PDF file name

--- a/PDF Merging API/JavaScript/Merge Encoded PDF Documents to Encoded Output (Node.js)/app.js
+++ b/PDF Merging API/JavaScript/Merge Encoded PDF Documents to Encoded Output (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -26,7 +26,7 @@ const SourceFiles = [
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 ];
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }";
 
 // Destination PDF file name

--- a/PDF Merging API/JavaScript/Merge PDF Documents (jQuery)/merge.js
+++ b/PDF Merging API/JavaScript/Merge PDF Documents (jQuery)/merge.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge PDF Documents From URLs (Node.js) - Async API/app.js
+++ b/PDF Merging API/JavaScript/Merge PDF Documents From URLs (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge PDF Documents From URLs (Node.js)/app.js
+++ b/PDF Merging API/JavaScript/Merge PDF Documents From URLs (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge PDF Documents From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Merging API/JavaScript/Merge PDF Documents From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/JavaScript/Merge PDF Documents From Uploaded File (Node.js)/app.js
+++ b/PDF Merging API/JavaScript/Merge PDF Documents From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/PHP/Merge Encoded PDF Documents to Encoded Output/merge-pdf-async.php
+++ b/PDF Merging API/PHP/Merge Encoded PDF Documents to Encoded Output/merge-pdf-async.php
@@ -22,7 +22,7 @@ $sourceFiles = array(
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf", 
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf");
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }";
 
 // Prepare URL for `Merge PDF` API call

--- a/PDF Merging API/PHP/Merge Encoded PDF Documents/merge-pdf-async.php
+++ b/PDF Merging API/PHP/Merge Encoded PDF Documents/merge-pdf-async.php
@@ -22,7 +22,7 @@ $sourceFiles = array(
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf", 
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf");
 
-// For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Prepare URL for `Merge PDF` API call

--- a/PDF Merging API/PowerShell/Merge Encoded PDF Documents to Encoded Output/MergePdfDocumentsFromUrlsAsynchronously.ps1
+++ b/PDF Merging API/PowerShell/Merge Encoded PDF Documents to Encoded Output/MergePdfDocumentsFromUrlsAsynchronously.ps1
@@ -11,7 +11,7 @@ $SourceFiles = @(
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 )
 
-# For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }"
 
 # Destination PDF file name

--- a/PDF Merging API/PowerShell/Merge Encoded PDF Documents/MergePdfDocumentsFromUrlsAsynchronously.ps1
+++ b/PDF Merging API/PowerShell/Merge Encoded PDF Documents/MergePdfDocumentsFromUrlsAsynchronously.ps1
@@ -11,7 +11,7 @@ $SourceFiles = @(
     "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"
 )
 
-# For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 # Destination PDF file name

--- a/PDF Merging API/VB.NET/Async file upload and async Merge PDF/Module1.vb
+++ b/PDF Merging API/VB.NET/Async file upload and async Merge PDF/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Async file upload and async Merge PDF/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Async file upload and async Merge PDF/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Any Documents From URLs Asynchronously/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge Any Documents From URLs Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Any Documents From URLs Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge Any Documents From URLs Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Any Documents From URLs/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge Any Documents From URLs/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Any Documents From URLs/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge Any Documents From URLs/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Encoded PDF Documents to Encoded Output/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge Encoded PDF Documents to Encoded Output/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -31,7 +31,7 @@ Module Module1
 		"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
 		"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"}
 
-	' For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	' For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234', 'DataEncryptionAlgorithm': 'AES128', 'DataEncryptionKey': 'HelloThisKey1234', 'DataEncryptionIV': 'TreloThisKey1234' }"
 
 	' Destination PDF file name

--- a/PDF Merging API/VB.NET/Merge Encoded PDF Documents to Encoded Output/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge Encoded PDF Documents to Encoded Output/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge Encoded PDF Documents/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge Encoded PDF Documents/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -31,7 +31,7 @@ Module Module1
 		"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf",
 		"https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-files/cloud-api/encryption/sample_encrypted_aes128.pdf"}
 
-	' For more information, refer to documentations at https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	' For more information, refer to documentations at https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 	' Destination PDF file name

--- a/PDF Merging API/VB.NET/Merge Encoded PDF Documents/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge Encoded PDF Documents/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From URLs Asynchronously/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From URLs Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From URLs Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From URLs Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From URLs/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From URLs/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From URLs/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From URLs/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From Uploaded Files/Module1.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From Uploaded Files/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/VB.NET/Merge PDF Documents From Uploaded Files/My Project/AssemblyInfo.vb
+++ b/PDF Merging API/VB.NET/Merge PDF Documents From Uploaded Files/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Merging API/n8n/Automated Document Assembly and Management/createAssemblyPlan.js
+++ b/PDF Merging API/n8n/Automated Document Assembly and Management/createAssemblyPlan.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Merging API/n8n/Automated Document Assembly and Management/prepareDocumentInputs.js
+++ b/PDF Merging API/n8n/Automated Document Assembly and Management/prepareDocumentInputs.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Advanced Optimize PDF From URL/Program.cs
+++ b/PDF Optimization API/C#/Advanced Optimize PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Advanced Optimize PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Optimization API/C#/Advanced Optimize PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From URL Asynchronously/Program.cs
+++ b/PDF Optimization API/C#/Optimize PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Optimization API/C#/Optimize PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From URL/Program.cs
+++ b/PDF Optimization API/C#/Optimize PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Optimization API/C#/Optimize PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From Uploaded File/Program.cs
+++ b/PDF Optimization API/C#/Optimize PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/C#/Optimize PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Optimization API/C#/Optimize PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/Java/Advanced Optimize PDF From URL/src/com/company/Main.java
+++ b/PDF Optimization API/Java/Advanced Optimize PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/Java/Optimize PDF From URL/src/com/company/Main.java
+++ b/PDF Optimization API/Java/Optimize PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/Java/Optimize PDF From Uploaded File/src/com/company/Main.java
+++ b/PDF Optimization API/Java/Optimize PDF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/JavaScript/Advanced Optimize PDF From URL (Node.js)/app.js
+++ b/PDF Optimization API/JavaScript/Advanced Optimize PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/JavaScript/Optimize PDF From URL (Node.js) - Async API/app.js
+++ b/PDF Optimization API/JavaScript/Optimize PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/JavaScript/Optimize PDF From URL (Node.js)/app.js
+++ b/PDF Optimization API/JavaScript/Optimize PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/JavaScript/Optimize PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Optimization API/JavaScript/Optimize PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/JavaScript/Optimize PDF From Uploaded File (Node.js)/app.js
+++ b/PDF Optimization API/JavaScript/Optimize PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Optimization API/VB.NET/Advanced Optimize PDF From URL/Module1.vb
+++ b/PDF Optimization API/VB.NET/Advanced Optimize PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Advanced Optimize PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Optimization API/VB.NET/Advanced Optimize PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From URL Asynchronously/Module1.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From URL/Module1.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From Uploaded File/Module1.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Optimization API/VB.NET/Optimize PDF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Optimization API/VB.NET/Optimize PDF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Password And Security/AWS Lambda/Protect PDF Document/app.js
+++ b/PDF Password And Security/AWS Lambda/Protect PDF Document/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/AWS Lambda/Remove PDF Document Protection/app.js
+++ b/PDF Password And Security/AWS Lambda/Remove PDF Document Protection/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/C#/Protect PDF Document/Program.cs
+++ b/PDF Password And Security/C#/Protect PDF Document/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/C#/Protect PDF Document/Properties/AssemblyInfo.cs
+++ b/PDF Password And Security/C#/Protect PDF Document/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/C#/Remove PDF Document Protection/Program.cs
+++ b/PDF Password And Security/C#/Remove PDF Document Protection/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/C#/Remove PDF Document Protection/Properties/AssemblyInfo.cs
+++ b/PDF Password And Security/C#/Remove PDF Document Protection/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/Java/Protect PDF Document/src/com/company/Main.java
+++ b/PDF Password And Security/Java/Protect PDF Document/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/Java/Remove PDF Document Protection/src/com/company/Main.java
+++ b/PDF Password And Security/Java/Remove PDF Document Protection/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/JavaScript/Protect PDF Asynchronously/app.js
+++ b/PDF Password And Security/JavaScript/Protect PDF Asynchronously/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/JavaScript/Protect PDF Document/app.js
+++ b/PDF Password And Security/JavaScript/Protect PDF Document/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/JavaScript/Remove PDF Document Protection Asynchronously/app.js
+++ b/PDF Password And Security/JavaScript/Remove PDF Document Protection Asynchronously/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/JavaScript/Remove PDF Document Protection/app.js
+++ b/PDF Password And Security/JavaScript/Remove PDF Document Protection/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Password And Security/VB.NET/Protect PDF Document/Module1.vb
+++ b/PDF Password And Security/VB.NET/Protect PDF Document/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Password And Security/VB.NET/Remove PDF Document Protection/Module1.vb
+++ b/PDF Password And Security/VB.NET/Remove PDF Document Protection/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/C#/Auto Rotate PDF From URL/Program.cs
+++ b/PDF Rotate Pages/C#/Auto Rotate PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/C#/Auto Rotate PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Rotate Pages/C#/Auto Rotate PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/C#/Rotate PDF From URL Asynchronously/Program.cs
+++ b/PDF Rotate Pages/C#/Rotate PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/C#/Rotate PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Rotate Pages/C#/Rotate PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/C#/Rotate PDF From URL/Program.cs
+++ b/PDF Rotate Pages/C#/Rotate PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/C#/Rotate PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Rotate Pages/C#/Rotate PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/Java/Auto Rotate PDF From URL/src/com/company/Main.java
+++ b/PDF Rotate Pages/Java/Auto Rotate PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/Java/Rotate PDF From URL/src/com/company/Main.java
+++ b/PDF Rotate Pages/Java/Rotate PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/JavaScript/Auto Rotate PDF From URL (Node.js)/app.js
+++ b/PDF Rotate Pages/JavaScript/Auto Rotate PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/JavaScript/Rotate PDF From URL (Node.js) - Async API/app.js
+++ b/PDF Rotate Pages/JavaScript/Rotate PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/JavaScript/Rotate PDF From URL (Node.js)/app.js
+++ b/PDF Rotate Pages/JavaScript/Rotate PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Rotate Pages/VB.NET/Auto Rotate PDF From URL/Module1.vb
+++ b/PDF Rotate Pages/VB.NET/Auto Rotate PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/VB.NET/Auto Rotate PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Rotate Pages/VB.NET/Auto Rotate PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/VB.NET/Rotate PDF From URL Asynchronously/Module1.vb
+++ b/PDF Rotate Pages/VB.NET/Rotate PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/VB.NET/Rotate PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Rotate Pages/VB.NET/Rotate PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/VB.NET/Rotate PDF From URL/Module1.vb
+++ b/PDF Rotate Pages/VB.NET/Rotate PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Rotate Pages/VB.NET/Rotate PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Rotate Pages/VB.NET/Rotate PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Search Tables/C#/PDF Table Search from URL Asynchronously/Program.cs
+++ b/PDF Search Tables/C#/PDF Table Search from URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/C#/PDF Table Search from URL/Program.cs
+++ b/PDF Search Tables/C#/PDF Table Search from URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/C#/PDF Table Search from Uploaded File Asynchronously/Program.cs
+++ b/PDF Search Tables/C#/PDF Table Search from Uploaded File Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/C#/PDF Table Search from Uploaded File/Program.cs
+++ b/PDF Search Tables/C#/PDF Table Search from Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/Java/PDF Table Search from URL Asynchronously/src/com/company/Main.java
+++ b/PDF Search Tables/Java/PDF Table Search from URL Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/Java/PDF Table Search from URL/src/com/company/Main.java
+++ b/PDF Search Tables/Java/PDF Table Search from URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/Java/PDF Table Search from Uploaded File Asynchronously/src/com/company/Main.java
+++ b/PDF Search Tables/Java/PDF Table Search from Uploaded File Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/Java/PDF Table Search from Uploaded File/src/com/company/Main.java
+++ b/PDF Search Tables/Java/PDF Table Search from Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/JavaScript/PDF Get Search Table JSON (Node js)/app.js
+++ b/PDF Search Tables/JavaScript/PDF Get Search Table JSON (Node js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/JavaScript/PDF Table Search from URL (Node js) - Async API/app.js
+++ b/PDF Search Tables/JavaScript/PDF Table Search from URL (Node js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/JavaScript/PDF Table Search from URL (Node js)/app.js
+++ b/PDF Search Tables/JavaScript/PDF Table Search from URL (Node js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/JavaScript/PDF Table Search from Uploaded File (Node js) - Async API/app.js
+++ b/PDF Search Tables/JavaScript/PDF Table Search from Uploaded File (Node js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/JavaScript/PDF Table Search from Uploaded File (Node js)/app.js
+++ b/PDF Search Tables/JavaScript/PDF Table Search from Uploaded File (Node js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Search Tables/VB.NET/PDF Table Search from URL Asynchronously/Module1.vb
+++ b/PDF Search Tables/VB.NET/PDF Table Search from URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Search Tables/VB.NET/PDF Table Search from URL/Module1.vb
+++ b/PDF Search Tables/VB.NET/PDF Table Search from URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Search Tables/VB.NET/PDF Table Search from Uploaded File Asynchronously/Module1.vb
+++ b/PDF Search Tables/VB.NET/PDF Table Search from Uploaded File Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Search Tables/VB.NET/PDF Table Search from Uploaded File/Module1.vb
+++ b/PDF Search Tables/VB.NET/PDF Table Search from Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/AWS Lambda/Split PDF By Barcode From URL (Node.js)/app.js
+++ b/PDF Splitting API/AWS Lambda/Split PDF By Barcode From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/AWS Lambda/Split PDF By Text From URL (Node.js)/app.js
+++ b/PDF Splitting API/AWS Lambda/Split PDF By Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/AWS Lambda/Split PDF From URL (Node.js)/app.js
+++ b/PDF Splitting API/AWS Lambda/Split PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF By Barcode/Program.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF By Barcode/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF By Barcode/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF By Barcode/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF By Text/Program.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF By Text/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF By Text/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF By Text/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF/Program.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Async file upload and async Split PDF/obj/Debug/.NETFramework,Version=v4.0.AssemblyAttributes.cs
+++ b/PDF Splitting API/C#/Async file upload and async Split PDF/obj/Debug/.NETFramework,Version=v4.0.AssemblyAttributes.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From URL Asynchronously/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From URL/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From URL/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From Uploaded File/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Barcode From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Barcode From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From URL Asynchronously/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From URL/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From URL/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From Uploaded File/Program.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF By Text From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF By Text From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From URL Asynchronously/Program.cs
+++ b/PDF Splitting API/C#/Split PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From URL/Program.cs
+++ b/PDF Splitting API/C#/Split PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From URL/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From Uploaded File/Program.cs
+++ b/PDF Splitting API/C#/Split PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/C#/Split PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF Splitting API/C#/Split PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF By Barcode From URL/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF By Barcode From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF By Barcode From Uploaded File/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF By Barcode From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF By Text From URL/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF By Text From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF By Text From Uploaded File/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF By Text From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF From URL/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/Java/Split PDF From Uploaded File/src/com/company/Main.java
+++ b/PDF Splitting API/Java/Split PDF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Barcode From URL (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Barcode From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Barcode From URL (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Barcode From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Barcode From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Barcode From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Barcode From Uploaded File (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Barcode From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Text From URL (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Text From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Text From URL (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Text From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Text From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF By Text From Uploaded File (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF By Text From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF From URL (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF From URL (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/JavaScript/Split PDF From Uploaded File (Node.js)/app.js
+++ b/PDF Splitting API/JavaScript/Split PDF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Barcode/Module1.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Barcode/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Barcode/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Barcode/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Text/Module1.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Text/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Text/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF By Text/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF/Module1.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Async file upload and async Split PDF/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Async file upload and async Split PDF/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From URL Asynchronously/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From URL/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From URL/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From Uploaded File/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Barcode From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Barcode From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From URL Asynchronously/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From URL/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From URL/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From Uploaded File/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF By Text From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF By Text From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From URL Asynchronously/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From URL/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From Uploaded File/Module1.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Splitting API/VB.NET/Split PDF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF Splitting API/VB.NET/Split PDF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Text Search API/C#/Async file upload and async Search Text/Program.cs
+++ b/PDF Text Search API/C#/Async file upload and async Search Text/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/C#/PDF Text Search from URL Asynchronously/Program.cs
+++ b/PDF Text Search API/C#/PDF Text Search from URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/C#/PDF Text Search from URL/Program.cs
+++ b/PDF Text Search API/C#/PDF Text Search from URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/C#/PDF Text Search from Uploaded File Asynchronously/Program.cs
+++ b/PDF Text Search API/C#/PDF Text Search from Uploaded File Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/C#/PDF Text Search from Uploaded File/Program.cs
+++ b/PDF Text Search API/C#/PDF Text Search from Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/C#/Search Amount in PDF File from URL Asynchronously/program.cs
+++ b/PDF Text Search API/C#/Search Amount in PDF File from URL Asynchronously/program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/Java/PDF Text Search from URL Asynchronously/src/com/company/Main.java
+++ b/PDF Text Search API/Java/PDF Text Search from URL Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/Java/PDF Text Search from URL/src/com/company/Main.java
+++ b/PDF Text Search API/Java/PDF Text Search from URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/Java/PDF Text Search from Uploaded File Asynchronously/src/com/company/Main.java
+++ b/PDF Text Search API/Java/PDF Text Search from Uploaded File Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/Java/PDF Text Search from Uploaded File/src/com/company/Main.java
+++ b/PDF Text Search API/Java/PDF Text Search from Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/JavaScript/PDF Text Search from URL (Node js) - Async API/app.js
+++ b/PDF Text Search API/JavaScript/PDF Text Search from URL (Node js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/JavaScript/PDF Text Search from URL (Node js)/app.js
+++ b/PDF Text Search API/JavaScript/PDF Text Search from URL (Node js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/JavaScript/PDF Text Search from Uploaded File (Node js) - Async API/app.js
+++ b/PDF Text Search API/JavaScript/PDF Text Search from Uploaded File (Node js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/JavaScript/PDF Text Search from Uploaded File (Node js)/app.js
+++ b/PDF Text Search API/JavaScript/PDF Text Search from Uploaded File (Node js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF Text Search API/VB.NET/Async file upload and async Search Text/Module1.vb
+++ b/PDF Text Search API/VB.NET/Async file upload and async Search Text/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Text Search API/VB.NET/PDF Text Search from URL Asynchronously/Module1.vb
+++ b/PDF Text Search API/VB.NET/PDF Text Search from URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Text Search API/VB.NET/PDF Text Search from URL/Module1.vb
+++ b/PDF Text Search API/VB.NET/PDF Text Search from URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Text Search API/VB.NET/PDF Text Search from Uploaded File Asynchronously/Module1.vb
+++ b/PDF Text Search API/VB.NET/PDF Text Search from Uploaded File Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF Text Search API/VB.NET/PDF Text Search from Uploaded File/Module1.vb
+++ b/PDF Text Search API/VB.NET/PDF Text Search from Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/AWS Lambda/Convert PDF To CSV From URL (Node.js)/app.js
+++ b/PDF To CSV API/AWS Lambda/Convert PDF To CSV From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Advanced Conversion Options With Rotated Input/Program.cs
+++ b/PDF To CSV API/C#/Advanced Conversion Options With Rotated Input/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
+++ b/PDF To CSV API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Advanced Conversion Options/Program.cs
+++ b/PDF To CSV API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Async file upload and async PDF to CSV/Program.cs
+++ b/PDF To CSV API/C#/Async file upload and async PDF to CSV/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Async file upload and async PDF to CSV/Properties/AssemblyInfo.cs
+++ b/PDF To CSV API/C#/Async file upload and async PDF to CSV/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From URL Asynchronously/Program.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From URL/Program.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From URL/Properties/AssemblyInfo.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From Uploaded File/Program.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/C#/Convert PDF To CSV From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To CSV API/C#/Convert PDF To CSV From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Advanced Conversion Options/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Advanced Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF To CSV From URL/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Convert PDF To CSV From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF To CSV From Uploaded File Asynchronously/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Convert PDF To CSV From Uploaded File Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF To CSV From Uploaded File/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Convert PDF To CSV From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/com/company/Main.java
+++ b/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/main/java/App.java
+++ b/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
+++ b/PDF To CSV API/Java/Convert PDF to CSV From URL Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
+++ b/PDF To CSV API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF To CSV API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF To CSV From URL (Node.js) - Async API/app.js
+++ b/PDF To CSV API/JavaScript/Convert PDF To CSV From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF To CSV From URL (Node.js)/app.js
+++ b/PDF To CSV API/JavaScript/Convert PDF To CSV From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF To CSV From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To CSV API/JavaScript/Convert PDF To CSV From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF To CSV From Uploaded File (Node.js)/app.js
+++ b/PDF To CSV API/JavaScript/Convert PDF To CSV From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF to CSV in JQuery - Async API/converter.js
+++ b/PDF To CSV API/JavaScript/Convert PDF to CSV in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/JavaScript/Convert PDF to CSV in JQuery/converter.js
+++ b/PDF To CSV API/JavaScript/Convert PDF to CSV in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/SharePoint/Convert PDF To CSV/Utils.cs
+++ b/PDF To CSV API/SharePoint/Convert PDF To CSV/Utils.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/SharePoint/Convert PDF To CSV/VisualWebPart1/VisualWebPart1.cs
+++ b/PDF To CSV API/SharePoint/Convert PDF To CSV/VisualWebPart1/VisualWebPart1.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/SharePoint/Convert PDF To CSV/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
+++ b/PDF To CSV API/SharePoint/Convert PDF To CSV/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To CSV API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
+++ b/PDF To CSV API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
+++ b/PDF To CSV API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF To CSV API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Async file upload and async PDF to CSV/Module1.vb
+++ b/PDF To CSV API/VB.NET/Async file upload and async PDF to CSV/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Async file upload and async PDF to CSV/My Project/AssemblyInfo.vb
+++ b/PDF To CSV API/VB.NET/Async file upload and async PDF to CSV/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From URL Asynchronously/Module1.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From URL/Module1.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From URL/My Project/AssemblyInfo.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From Uploaded File/Module1.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To CSV API/VB.NET/Convert PDF To CSV From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To CSV API/VB.NET/Convert PDF To CSV From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/AWS Lambda/Convert PDF To HTML From URL (Node.js)/app.js
+++ b/PDF To HTML API/AWS Lambda/Convert PDF To HTML From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From URL Asynchronously/Program.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From URL/Program.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From URL/Properties/AssemblyInfo.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From Uploaded File/Program.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/C#/Convert PDF To HTML From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To HTML API/C#/Convert PDF To HTML From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF To HTML From URL/src/com/company/Main.java
+++ b/PDF To HTML API/Java/Convert PDF To HTML From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF To HTML From Uploaded File/src/com/company/Main.java
+++ b/PDF To HTML API/Java/Convert PDF To HTML From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/com/company/Main.java
+++ b/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/target/classes/archetype-resources/src/main/java/App.java
+++ b/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/target/classes/archetype-resources/src/main/java/App.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
+++ b/PDF To HTML API/Java/Convert PDF to HTML From Uploaded File Asynchronously/target/classes/archetype-resources/src/test/java/AppTest.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML From URL (Node.js) - Async API/app.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML From URL (Node.js)/app.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML From Uploaded File (Node.js)/app.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML in JQuery - Async API/converter.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/JavaScript/Convert PDF To HTML in JQuery/converter.js
+++ b/PDF To HTML API/JavaScript/Convert PDF To HTML in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From URL Asynchronously/Module1.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From URL/Module1.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From URL/My Project/AssemblyInfo.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From Uploaded File/Module1.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To HTML API/VB.NET/Convert PDF To HTML From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To HTML API/VB.NET/Convert PDF To HTML From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/AWS Lambda/Convert Encoded PDF To JPEG From URL (Node.js)/app.js
+++ b/PDF To JPG/AWS Lambda/Convert Encoded PDF To JPEG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -22,7 +22,7 @@ const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/de
 // Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 const Pages = "";
 
-//  Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+//  Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 

--- a/PDF To JPG/AWS Lambda/Convert PDF To JPEG From URL (Node.js)/app.js
+++ b/PDF To JPG/AWS Lambda/Convert PDF To JPEG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Advanced JPEG Conversion Options/Program.cs
+++ b/PDF To JPG/C#/Advanced JPEG Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert Encoded PDF To JPEG From URL/Program.cs
+++ b/PDF To JPG/C#/Convert Encoded PDF To JPEG From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -30,7 +30,7 @@ namespace ByteScoutWebApiExample
 		// Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 		const string Pages = "";
 
-		// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+		// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 		const string Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 		
 		static void Main(string[] args)

--- a/PDF To JPG/C#/Convert Encoded PDF To JPEG From URL/Properties/AssemblyInfo.cs
+++ b/PDF To JPG/C#/Convert Encoded PDF To JPEG From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From URL Asynchronously/Program.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From URL/Program.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From URL/Properties/AssemblyInfo.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From Uploaded File/Program.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/C#/Convert PDF To JPEG From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To JPG/C#/Convert PDF To JPEG From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/Java/Advanced JPEG Conversion Options/src/com/company/Main.java
+++ b/PDF To JPG/Java/Advanced JPEG Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/Java/Convert Encoded PDF To JPEG From URL/src/com/company/Main.java
+++ b/PDF To JPG/Java/Convert Encoded PDF To JPEG From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -34,7 +34,7 @@ public class Main
     // Comma-separated list of page numbers (or ranges) to process. Leave empty for all pages. Example: '1,3-5,7-'.
     final static String Pages = "";
 
-    //  Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+    //  Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
     final static String Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 

--- a/PDF To JPG/Java/Convert PDF To JPEG From URL/src/com/company/Main.java
+++ b/PDF To JPG/Java/Convert PDF To JPEG From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/Java/Convert PDF To JPEG From Uploaded File/src/com/company/Main.java
+++ b/PDF To JPG/Java/Convert PDF To JPEG From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/JavaScript/Advanced JPEG Conversion Options/app.js
+++ b/PDF To JPG/JavaScript/Advanced JPEG Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/JavaScript/Convert Encoded PDF To JPEG From URL (Node.js) - Async API/app.js
+++ b/PDF To JPG/JavaScript/Convert Encoded PDF To JPEG From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -27,7 +27,7 @@ const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/de
 // Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 const Pages = "";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 

--- a/PDF To JPG/JavaScript/Convert Encoded PDF To JPEG From URL (Node.js)/app.js
+++ b/PDF To JPG/JavaScript/Convert Encoded PDF To JPEG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //
@@ -25,7 +25,7 @@ const SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/de
 // Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 const Pages = "";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 const Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 

--- a/PDF To JPG/JavaScript/Convert PDF To JPEG From URL (Node.js) - Async API/app.js
+++ b/PDF To JPG/JavaScript/Convert PDF To JPEG From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/JavaScript/Convert PDF To JPEG From URL (Node.js)/app.js
+++ b/PDF To JPG/JavaScript/Convert PDF To JPEG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/JavaScript/Convert PDF To JPEG From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To JPG/JavaScript/Convert PDF To JPEG From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/JavaScript/Convert PDF To JPEG From Uploaded File (Node.js)/app.js
+++ b/PDF To JPG/JavaScript/Convert PDF To JPEG From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JPG/PHP/Convert Encoded PDF To Image Asynchronously/pdf-to-jpeg-async.php
+++ b/PDF To JPG/PHP/Convert Encoded PDF To Image Asynchronously/pdf-to-jpeg-async.php
@@ -23,7 +23,7 @@ $sourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fi
 // Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 $pages = "";
 
-// Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+// Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }";
 
 // Prepare URL for `PDF To JPEG` API call

--- a/PDF To JPG/PowerShell/Convert Encoded PDF To JPEG From URL Asynchronously/ConvertPdfToJpegFromUrlAsynchronously.ps1
+++ b/PDF To JPG/PowerShell/Convert Encoded PDF To JPEG From URL Asynchronously/ConvertPdfToJpegFromUrlAsynchronously.ps1
@@ -11,7 +11,7 @@ $SourceFileUrl = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fi
 # Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 $Pages = ""
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 $Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 # (!) Make asynchronous job

--- a/PDF To JPG/Python/Convert Encoded PDF to Image From URL/ConvertPdfToImageFromURL.py
+++ b/PDF To JPG/Python/Convert Encoded PDF to Image From URL/ConvertPdfToImageFromURL.py
@@ -14,7 +14,7 @@ SourceFileURL = "https://bytescout-com.s3-us-west-2.amazonaws.com/files/demo-fil
 # Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 Pages = ""
 
-# Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+# Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 Profiles = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 def main(args = None):

--- a/PDF To JPG/VB.NET/Advanced JPEG Conversation Options/Module1.vb
+++ b/PDF To JPG/VB.NET/Advanced JPEG Conversation Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Advanced JPEG Conversation Options/My Project/AssemblyInfo.vb
+++ b/PDF To JPG/VB.NET/Advanced JPEG Conversation Options/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert Encoded PDF To JPEG From URL Asynchronously/Module1.vb
+++ b/PDF To JPG/VB.NET/Convert Encoded PDF To JPEG From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '
@@ -32,7 +32,7 @@ Module Module1
 	' Comma-separated list of page indices (or ranges) to process. Leave empty for all pages. Example: '0,2-5,7-'.
 	Const Pages As String = ""
 
-	' Refer to documentations for more info. https://docs.pdf.co/32-1-user-controlled-data-encryption-and-decryption
+	' Refer to documentations for more info. https://docs.pdf.co/knowledgebase/user-controlled-encryption
 	Const Profiles As String = "{ 'DataDecryptionAlgorithm': 'AES128', 'DataDecryptionKey': 'HelloThisKey1234', 'DataDecryptionIV': 'TreloThisKey1234' }"
 
 	' (!) Make asynchronous job

--- a/PDF To JPG/VB.NET/Convert Encoded PDF To JPEG From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To JPG/VB.NET/Convert Encoded PDF To JPEG From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From URL Asynchronously/Module1.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From URL/Module1.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From URL/My Project/AssemblyInfo.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From Uploaded File/Module1.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JPG/VB.NET/Convert PDF To JPEG From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To JPG/VB.NET/Convert PDF To JPEG From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/AWS Lambda/Convert PDF To JSON From URL (Node.js) (AI Powered)/app.js
+++ b/PDF To JSON API/AWS Lambda/Convert PDF To JSON From URL (Node.js) (AI Powered)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/AWS Lambda/Convert PDF To JSON From URL (Node.js)/app.js
+++ b/PDF To JSON API/AWS Lambda/Convert PDF To JSON From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Advanced Conversion Options With Rotated Input/Program.cs
+++ b/PDF To JSON API/C#/Advanced Conversion Options With Rotated Input/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Advanced Conversion Options/Program.cs
+++ b/PDF To JSON API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL (AI Powered)/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL (AI Powered)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL (AI Powered)/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL (AI Powered)/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously (AI Powered)/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously (AI Powered)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously (AI Powered)/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously (AI Powered)/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From URL/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File (AI Powered)/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File (AI Powered)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File (AI Powered)/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File (AI Powered)/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously (AI Powered)/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously (AI Powered)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously (AI Powered)/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously (AI Powered)/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File/Program.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To JSON API/C#/Convert PDF To JSON From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Advanced Conversion Options/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Advanced Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Convert PDF To JSON From URL (AI Powered)/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Convert PDF To JSON From URL (AI Powered)/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Convert PDF To JSON From URL/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Convert PDF To JSON From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Convert PDF To JSON From Uploaded File (AI Powered)/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Convert PDF To JSON From Uploaded File (AI Powered)/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/Java/Convert PDF To JSON From Uploaded File/src/com/company/Main.java
+++ b/PDF To JSON API/Java/Convert PDF To JSON From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
+++ b/PDF To JSON API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF To JSON API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) (AI Powered)/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) (AI Powered)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) - Async API (AI Powered)/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) - Async API (AI Powered)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) - Async API/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js)/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js) (AI Powered)/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js) (AI Powered)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js)/app.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON in JQuery - Async API/converter.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/JavaScript/Convert PDF To JSON in JQuery/converter.js
+++ b/PDF To JSON API/JavaScript/Convert PDF To JSON in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
+++ b/PDF To JSON API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF To JSON API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL (AI Powered)/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL (AI Powered)/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL (AI Powered)/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL (AI Powered)/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously (AI Powered)/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously (AI Powered)/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously (AI Powered)/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously (AI Powered)/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From URL/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File (AI Powered)/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File (AI Powered)/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File (AI Powered)/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File (AI Powered)/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File/Module1.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To JSON API/VB.NET/Convert PDF To JSON From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To JSON API/n8n/Smart PDF Processing Transform Any Document into Actionable Data/Data Structuring Code.js
+++ b/PDF To JSON API/n8n/Smart PDF Processing Transform Any Document into Actionable Data/Data Structuring Code.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To JSON API/n8n/Smart PDF Processing Transform Any Document into Actionable Data/Text Extraction Code.js
+++ b/PDF To JSON API/n8n/Smart PDF Processing Transform Any Document into Actionable Data/Text Extraction Code.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/AWS Lambda/Convert PDF To PNG From URL (Node.js)/app.js
+++ b/PDF To PNG/AWS Lambda/Convert PDF To PNG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Advanced PNG Conversion Options/Program.cs
+++ b/PDF To PNG/C#/Advanced PNG Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From URL Asynchronously/Program.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From URL/Program.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From URL/Properties/AssemblyInfo.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From Uploaded File/Program.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/C#/Convert PDF To PNG From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To PNG/C#/Convert PDF To PNG From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/Java/Advanced PNG Conversion Options/src/com/company/Main.java
+++ b/PDF To PNG/Java/Advanced PNG Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/Java/Convert PDF To PNG From URL/src/com/company/Main.java
+++ b/PDF To PNG/Java/Convert PDF To PNG From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/Java/Convert PDF To PNG From Uploaded File/src/com/company/Main.java
+++ b/PDF To PNG/Java/Convert PDF To PNG From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/JavaScript/Advanced PNG Conversion Options/app.js
+++ b/PDF To PNG/JavaScript/Advanced PNG Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/JavaScript/Convert PDF To PNG From URL (Node.js) - Async API/app.js
+++ b/PDF To PNG/JavaScript/Convert PDF To PNG From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/JavaScript/Convert PDF To PNG From URL (Node.js)/app.js
+++ b/PDF To PNG/JavaScript/Convert PDF To PNG From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/JavaScript/Convert PDF To PNG From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To PNG/JavaScript/Convert PDF To PNG From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/JavaScript/Convert PDF To PNG From Uploaded File (Node.js)/app.js
+++ b/PDF To PNG/JavaScript/Convert PDF To PNG From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To PNG/VB.NET/Advanced PNG Conversation Options/Module1.vb
+++ b/PDF To PNG/VB.NET/Advanced PNG Conversation Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Advanced PNG Conversation Options/My Project/AssemblyInfo.vb
+++ b/PDF To PNG/VB.NET/Advanced PNG Conversation Options/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From URL Asynchronously/Module1.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From URL/Module1.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From URL/My Project/AssemblyInfo.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From Uploaded File/Module1.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To PNG/VB.NET/Convert PDF To PNG From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To PNG/VB.NET/Convert PDF To PNG From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/AWS Lambda/Convert PDF To TIFF From URL (Node.js)/app.js
+++ b/PDF To TIFF/AWS Lambda/Convert PDF To TIFF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Advanced TIFF Conversion Options/Program.cs
+++ b/PDF To TIFF/C#/Advanced TIFF Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From URL Asynchronously/Program.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From URL/Program.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From URL/Properties/AssemblyInfo.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From Uploaded File/Program.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/C#/Convert PDF To TIFF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To TIFF/C#/Convert PDF To TIFF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/Java/Advanced TIFF Conversion Options/src/com/company/Main.java
+++ b/PDF To TIFF/Java/Advanced TIFF Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/Java/Convert PDF To TIFF From URL/src/com/company/Main.java
+++ b/PDF To TIFF/Java/Convert PDF To TIFF From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/Java/Convert PDF To TIFF From Uploaded File/src/com/company/Main.java
+++ b/PDF To TIFF/Java/Convert PDF To TIFF From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/JavaScript/Advanced TIFF Conversion Options/app.js
+++ b/PDF To TIFF/JavaScript/Advanced TIFF Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/JavaScript/Convert PDF To TIFF From URL (Node.js) - Async API/app.js
+++ b/PDF To TIFF/JavaScript/Convert PDF To TIFF From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/JavaScript/Convert PDF To TIFF From URL (Node.js)/app.js
+++ b/PDF To TIFF/JavaScript/Convert PDF To TIFF From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/JavaScript/Convert PDF To TIFF From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To TIFF/JavaScript/Convert PDF To TIFF From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/JavaScript/Convert PDF To TIFF From Uploaded File (Node.js)/app.js
+++ b/PDF To TIFF/JavaScript/Convert PDF To TIFF From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To TIFF/VB.NET/Advanced TIFF Conversation Options/Module1.vb
+++ b/PDF To TIFF/VB.NET/Advanced TIFF Conversation Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Advanced TIFF Conversation Options/My Project/AssemblyInfo.vb
+++ b/PDF To TIFF/VB.NET/Advanced TIFF Conversation Options/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL Asynchronously/Module1.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL/Module1.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL/My Project/AssemblyInfo.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From Uploaded File/Module1.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To TIFF/VB.NET/Convert PDF To TIFF From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To TIFF/VB.NET/Convert PDF To TIFF From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/AWS Lambda/Convert PDF To Text From URL (Node.js)/app.js
+++ b/PDF To Text API/AWS Lambda/Convert PDF To Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Advanced Conversion Options With Rotated Input/Program.cs
+++ b/PDF To Text API/C#/Advanced Conversion Options With Rotated Input/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
+++ b/PDF To Text API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Advanced Conversion Options/Program.cs
+++ b/PDF To Text API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Async file upload and async PDF to Text/Program.cs
+++ b/PDF To Text API/C#/Async file upload and async PDF to Text/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Async file upload and async PDF to Text/Properties/AssemblyInfo.cs
+++ b/PDF To Text API/C#/Async file upload and async PDF to Text/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From URL Asynchronously/Program.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From URL/Program.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From URL/Properties/AssemblyInfo.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From Uploaded File/Program.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/C#/Convert PDF To Text From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To Text API/C#/Convert PDF To Text From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/GoogleAppScript/Convert PDF to Text/program.gs
+++ b/PDF To Text API/GoogleAppScript/Convert PDF to Text/program.gs
@@ -1,5 +1,5 @@
 // Visit Knowledgebase for adding Text Macros to PDF 
-// https://docs.pdf.co/kb/Fill%20PDF%20and%20Add%20Text%20or%20Images%20(pdf-edit-add)/macros
+// https://docs.pdf.co/api-reference/pdf-add#macros
 
 // Handle PDF.co Menu on Google Sheet Open Event
 function onOpen() {

--- a/PDF To Text API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
+++ b/PDF To Text API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/Java/Advanced Conversion Options/src/com/company/Main.java
+++ b/PDF To Text API/Java/Advanced Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/Java/Convert PDF To Text From URL/src/com/company/Main.java
+++ b/PDF To Text API/Java/Convert PDF To Text From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/Java/Convert PDF To Text From Uploaded File/src/com/company/Main.java
+++ b/PDF To Text API/Java/Convert PDF To Text From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
+++ b/PDF To Text API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF To Text API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text From URL (Node.js) - Async API/app.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text From URL (Node.js)/app.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text From Uploaded File (Node.js)/app.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text in JQuery - Async API/converter.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/JavaScript/Convert PDF To Text in JQuery/converter.js
+++ b/PDF To Text API/JavaScript/Convert PDF To Text in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To Text API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
+++ b/PDF To Text API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
+++ b/PDF To Text API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF To Text API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Async file upload and async PDF to Text/Module1.vb
+++ b/PDF To Text API/VB.NET/Async file upload and async PDF to Text/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Async file upload and async PDF to Text/My Project/AssemblyInfo.vb
+++ b/PDF To Text API/VB.NET/Async file upload and async PDF to Text/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From URL Asynchronously/Module1.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From URL/Module1.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From URL/My Project/AssemblyInfo.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From Uploaded File/Module1.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To Text API/VB.NET/Convert PDF To Text From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To Text API/VB.NET/Convert PDF To Text From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/AWS Lambda/Convert PDF To XLS From URL (Node.js)/app.js
+++ b/PDF To XLS/AWS Lambda/Convert PDF To XLS From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Advanced Conversion Options With Rotated Input/Program.cs
+++ b/PDF To XLS/C#/Advanced Conversion Options With Rotated Input/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
+++ b/PDF To XLS/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Advanced Conversion Options/Program.cs
+++ b/PDF To XLS/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From URL Asynchronously/Program.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From URL/Program.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From URL/Properties/AssemblyInfo.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From Uploaded File (WinForms)/Form1.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From Uploaded File (WinForms)/Form1.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From Uploaded File (WinForms)/Program.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From Uploaded File (WinForms)/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From Uploaded File/Program.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/C#/Convert PDF To XLS From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To XLS/C#/Convert PDF To XLS From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
+++ b/PDF To XLS/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/Java/Advanced Conversion Options/src/com/company/Main.java
+++ b/PDF To XLS/Java/Advanced Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/Java/Convert PDF To XLS From URL/src/com/company/Main.java
+++ b/PDF To XLS/Java/Convert PDF To XLS From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/Java/Convert PDF To XLS From Uploaded File/src/com/company/Main.java
+++ b/PDF To XLS/Java/Convert PDF To XLS From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Advanced Conversion Options With Rotated Input/app.js
+++ b/PDF To XLS/JavaScript/Advanced Conversion Options With Rotated Input/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF To XLS/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Convert PDF To XLS From URL (Node.js) - Async API/app.js
+++ b/PDF To XLS/JavaScript/Convert PDF To XLS From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Convert PDF To XLS From URL (Node.js)/app.js
+++ b/PDF To XLS/JavaScript/Convert PDF To XLS From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Convert PDF To XLS From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To XLS/JavaScript/Convert PDF To XLS From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/JavaScript/Convert PDF To XLS From Uploaded File (Node.js)/app.js
+++ b/PDF To XLS/JavaScript/Convert PDF To XLS From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLS/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
+++ b/PDF To XLS/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
+++ b/PDF To XLS/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF To XLS/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Convert PDF To XLS From URL/Module1.vb
+++ b/PDF To XLS/VB.NET/Convert PDF To XLS From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Convert PDF To XLS From URL/My Project/AssemblyInfo.vb
+++ b/PDF To XLS/VB.NET/Convert PDF To XLS From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File (WinForms)/Form1.vb
+++ b/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File (WinForms)/Form1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File/Module1.vb
+++ b/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To XLS/VB.NET/Convert PDF To XLS From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/AWS Lambda/Convert PDF To XLSX From URL (Node.js)/app.js
+++ b/PDF To XLSX/AWS Lambda/Convert PDF To XLSX From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Pages/Error.cshtml.cs
+++ b/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Pages/Error.cshtml.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Program.cs
+++ b/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Startup.cs
+++ b/PDF To XLSX/Blazor/Convert PDF To XLSX From Uploaded File/Startup.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From URL Asynchronously/Program.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From URL/Program.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From URL/Properties/AssemblyInfo.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From Uploaded File/Program.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/C#/Convert PDF To XLSX From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To XLSX/C#/Convert PDF To XLSX From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/Java/Convert PDF To XLSX From URL/src/com/company/Main.java
+++ b/PDF To XLSX/Java/Convert PDF To XLSX From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/Java/Convert PDF To XLSX From Uploaded File/src/com/company/Main.java
+++ b/PDF To XLSX/Java/Convert PDF To XLSX From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX From URL (Node.js) - Async API/app.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX From URL (Node.js)/app.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX From Uploaded File (Node.js)/app.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX in JQuery - Async API/converter.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/JavaScript/Convert PDF To XLSX in JQuery/converter.js
+++ b/PDF To XLSX/JavaScript/Convert PDF To XLSX in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL Asynchronously/Module1.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL/Module1.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL/My Project/AssemblyInfo.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From Uploaded File/Module1.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XLSX/VB.NET/Convert PDF To XLSX From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To XLSX/VB.NET/Convert PDF To XLSX From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/AWS Lambda/Convert PDF To XML From URL (Node.js)/app.js
+++ b/PDF To XML API/AWS Lambda/Convert PDF To XML From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Advanced Conversion Options With Rotated Input/Program.cs
+++ b/PDF To XML API/C#/Advanced Conversion Options With Rotated Input/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
+++ b/PDF To XML API/C#/Advanced Conversion Options With Rotated Input/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Advanced Conversion Options/Program.cs
+++ b/PDF To XML API/C#/Advanced Conversion Options/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From URL Asynchronously/Program.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From URL/Program.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From URL/Properties/AssemblyInfo.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From Uploaded File/Program.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/C#/Convert PDF To XML From Uploaded File/Properties/AssemblyInfo.cs
+++ b/PDF To XML API/C#/Convert PDF To XML From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
+++ b/PDF To XML API/Java/Advanced Conversion Options With Rotated Input/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/Java/Advanced Conversion Options/src/com/company/Main.java
+++ b/PDF To XML API/Java/Advanced Conversion Options/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/Java/Convert PDF To XML From URL/src/com/company/Main.java
+++ b/PDF To XML API/Java/Convert PDF To XML From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/Java/Convert PDF To XML From Uploaded File/src/com/company/Main.java
+++ b/PDF To XML API/Java/Convert PDF To XML From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
+++ b/PDF To XML API/JavaScript/Advanced Conversion Options With Rotated Input/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Advanced Conversion Options/app.js
+++ b/PDF To XML API/JavaScript/Advanced Conversion Options/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML From URL (Node.js) - Async API/app.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML From URL (Node.js)/app.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML From Uploaded File (Node.js) - Async API/app.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML From Uploaded File (Node.js)/app.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML in JQuery - Async API/converter.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML in JQuery - Async API/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF To XML in JQuery/converter.js
+++ b/PDF To XML API/JavaScript/Convert PDF To XML in JQuery/converter.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/JavaScript/Convert PDF to XML from Uploaded File Asynchronously/Convert PDF to XML from Uploaded File Asynchronously.js
+++ b/PDF To XML API/JavaScript/Convert PDF to XML from Uploaded File Asynchronously/Convert PDF to XML from Uploaded File Asynchronously.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF To XML API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
+++ b/PDF To XML API/VB.NET/Advanced Conversion Options With Rotated Input/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
+++ b/PDF To XML API/VB.NET/Advanced Conversion Options With Rotated Input/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Advanced Conversion Options/Module1.vb
+++ b/PDF To XML API/VB.NET/Advanced Conversion Options/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From URL Asynchronously/Module1.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From URL/Module1.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From URL/My Project/AssemblyInfo.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From Uploaded File/Module1.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF To XML API/VB.NET/Convert PDF To XML From Uploaded File/My Project/AssemblyInfo.vb
+++ b/PDF To XML API/VB.NET/Convert PDF To XML From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML template/C#/CCDA record to PDF/Program.cs
+++ b/PDF from HTML template/C#/CCDA record to PDF/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/CCDA record to PDF/Properties/AssemblyInfo.cs
+++ b/PDF from HTML template/C#/CCDA record to PDF/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/CCDA record to PDF/ResultVM.cs
+++ b/PDF from HTML template/C#/CCDA record to PDF/ResultVM.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Generate PDF Invoice From HTML Template/Program.cs
+++ b/PDF from HTML template/C#/Generate PDF Invoice From HTML Template/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Generate PDF Invoice From HTML Template/Properties/AssemblyInfo.cs
+++ b/PDF from HTML template/C#/Generate PDF Invoice From HTML Template/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Generate PDF Quotation/Program.cs
+++ b/PDF from HTML template/C#/Generate PDF Quotation/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Generate PDF Quotation/Properties/AssemblyInfo.cs
+++ b/PDF from HTML template/C#/Generate PDF Quotation/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Generate Simple Invoice with QR Code Asynchronously/program.cs
+++ b/PDF from HTML template/C#/Generate Simple Invoice with QR Code Asynchronously/program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Invoice With Multiple Pages/Program.cs
+++ b/PDF from HTML template/C#/Invoice With Multiple Pages/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Invoice With Multiple Pages/Properties/AssemblyInfo.cs
+++ b/PDF from HTML template/C#/Invoice With Multiple Pages/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/C#/Template Iterating Array/Program.cs
+++ b/PDF from HTML template/C#/Template Iterating Array/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/Java/Generate PDF Invoice From HTML Template/src/com/company/Main.java
+++ b/PDF from HTML template/Java/Generate PDF Invoice From HTML Template/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/Java/Invoice With Multiple Pages/src/com/company/Main.java
+++ b/PDF from HTML template/Java/Invoice With Multiple Pages/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/JavaScript/Generate PDF Invoice From HTML Template (Node.js) - Async API/app.js
+++ b/PDF from HTML template/JavaScript/Generate PDF Invoice From HTML Template (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/JavaScript/Generate PDF Invoice From HTML Template (Node.js)/app.js
+++ b/PDF from HTML template/JavaScript/Generate PDF Invoice From HTML Template (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/JavaScript/Invoice With Multiple Pages (Node.js) - Async API/app.js
+++ b/PDF from HTML template/JavaScript/Invoice With Multiple Pages (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/JavaScript/Invoice With Multiple Pages (Node.js)/app.js
+++ b/PDF from HTML template/JavaScript/Invoice With Multiple Pages (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/JavaScript/Temple Iterating Array/app.js
+++ b/PDF from HTML template/JavaScript/Temple Iterating Array/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML template/VB.NET/Generate PDF Invoice From HTML Template/Module1.vb
+++ b/PDF from HTML template/VB.NET/Generate PDF Invoice From HTML Template/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML template/VB.NET/Generate PDF Invoice From HTML Template/My Project/AssemblyInfo.vb
+++ b/PDF from HTML template/VB.NET/Generate PDF Invoice From HTML Template/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML template/VB.NET/Invoice With Multiple Pages/Module1.vb
+++ b/PDF from HTML template/VB.NET/Invoice With Multiple Pages/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML template/VB.NET/Invoice With Multiple Pages/My Project/AssemblyInfo.vb
+++ b/PDF from HTML template/VB.NET/Invoice With Multiple Pages/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML template/n8n/Generate Sales Quote with QR Code/code.js
+++ b/PDF from HTML template/n8n/Generate Sales Quote with QR Code/code.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/C#/Generate PDF From HTML File/Program.cs
+++ b/PDF from HTML/C#/Generate PDF From HTML File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/C#/Generate PDF From Large HTML File/Program.cs
+++ b/PDF from HTML/C#/Generate PDF From Large HTML File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/Java/Generate PDF From HTML File/src/com/company/Main.java
+++ b/PDF from HTML/Java/Generate PDF From HTML File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/Java/Generate PDF From Large HTML File/src/com/company/Main.java
+++ b/PDF from HTML/Java/Generate PDF From Large HTML File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/JavaScript/Generate PDF From HTML File/app.js
+++ b/PDF from HTML/JavaScript/Generate PDF From HTML File/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/JavaScript/Generate PDF From Large HTML File/app.js
+++ b/PDF from HTML/JavaScript/Generate PDF From Large HTML File/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/Utils.cs
+++ b/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/Utils.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/VisualWebPart1.cs
+++ b/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/VisualWebPart1.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
+++ b/PDF from HTML/SharePoint/Convert HTML to PDF/VisualWebPart1/VisualWebPart1UserControl.ascx.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from HTML/VB.NET/Generate PDF From HTML File/Module1.vb
+++ b/PDF from HTML/VB.NET/Generate PDF From HTML File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from HTML/VB.NET/Generate PDF From Large HTML File/Module1.vb
+++ b/PDF from HTML/VB.NET/Generate PDF From Large HTML File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from URL/AWS Lambda/Convert Web Page To PDF From Link (Node.js)/app.js
+++ b/PDF from URL/AWS Lambda/Convert Web Page To PDF From Link (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/C#/Convert Web Page To PDF From Link Asynchronously/Program.cs
+++ b/PDF from URL/C#/Convert Web Page To PDF From Link Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/C#/Convert Web Page To PDF From Link Asynchronously/Properties/AssemblyInfo.cs
+++ b/PDF from URL/C#/Convert Web Page To PDF From Link Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/C#/Convert Web Page To PDF From Link/Program.cs
+++ b/PDF from URL/C#/Convert Web Page To PDF From Link/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/C#/Convert Web Page To PDF From Link/Properties/AssemblyInfo.cs
+++ b/PDF from URL/C#/Convert Web Page To PDF From Link/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/Java/Convert Web Page To PDF From Link/src/com/company/Main.java
+++ b/PDF from URL/Java/Convert Web Page To PDF From Link/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/JavaScript/Convert Web Page To PDF From Link (Node.js) - Async API/app.js
+++ b/PDF from URL/JavaScript/Convert Web Page To PDF From Link (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/JavaScript/Convert Web Page To PDF From Link (Node.js)/app.js
+++ b/PDF from URL/JavaScript/Convert Web Page To PDF From Link (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/PDF from URL/VB.NET/Convert Web Page To PDF From URL Asynchronously/Module1.vb
+++ b/PDF from URL/VB.NET/Convert Web Page To PDF From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from URL/VB.NET/Convert Web Page To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/PDF from URL/VB.NET/Convert Web Page To PDF From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from URL/VB.NET/Convert Web Page To PDF From URL/Module1.vb
+++ b/PDF from URL/VB.NET/Convert Web Page To PDF From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/PDF from URL/VB.NET/Convert Web Page To PDF From URL/My Project/AssemblyInfo.vb
+++ b/PDF from URL/VB.NET/Convert Web Page To PDF From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Render Url As Jpg/AWS Lambda/Render Url To Jpg (Node.js)/app.js
+++ b/Render Url As Jpg/AWS Lambda/Render Url To Jpg (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/C#/Render Url To Jpg/Program.cs
+++ b/Render Url As Jpg/C#/Render Url To Jpg/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/C#/Render Url To Jpg/Properties/AssemblyInfo.cs
+++ b/Render Url As Jpg/C#/Render Url To Jpg/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/Java/Render Url To Jpg/src/com/company/Main.java
+++ b/Render Url As Jpg/Java/Render Url To Jpg/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/JavaScript/Render Url To Jpg (Node.js) - Async API/app.js
+++ b/Render Url As Jpg/JavaScript/Render Url To Jpg (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/JavaScript/Render Url To Jpg (Node.js)/app.js
+++ b/Render Url As Jpg/JavaScript/Render Url To Jpg (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Jpg/VB.NET/Render Url To Jpg/Module1.vb
+++ b/Render Url As Jpg/VB.NET/Render Url To Jpg/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Render Url As Jpg/VB.NET/Render Url To Jpg/My Project/AssemblyInfo.vb
+++ b/Render Url As Jpg/VB.NET/Render Url To Jpg/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Render Url As Png/AWS Lambda/Render Url To Png (Node.js)/app.js
+++ b/Render Url As Png/AWS Lambda/Render Url To Png (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/C#/Render Url To Png/Program.cs
+++ b/Render Url As Png/C#/Render Url To Png/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/C#/Render Url To Png/Properties/AssemblyInfo.cs
+++ b/Render Url As Png/C#/Render Url To Png/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/Java/Render Url To Png/src/com/company/Main.java
+++ b/Render Url As Png/Java/Render Url To Png/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/JavaScript/Render Url To Png (Node.js) - Async API/app.js
+++ b/Render Url As Png/JavaScript/Render Url To Png (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/JavaScript/Render Url To Png (Node.js)/app.js
+++ b/Render Url As Png/JavaScript/Render Url To Png (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Render Url As Png/VB.NET/Render Url To Png/Module1.vb
+++ b/Render Url As Png/VB.NET/Render Url To Png/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Render Url As Png/VB.NET/Render Url To Png/My Project/AssemblyInfo.vb
+++ b/Render Url As Png/VB.NET/Render Url To Png/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/AWS Lambda/Replace Text From URL (Node.js)/app.js
+++ b/Replace Text From PDF/AWS Lambda/Replace Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From URL Asynchronously/Program.cs
+++ b/Replace Text From PDF/C#/Replace Text From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/Replace Text From PDF/C#/Replace Text From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From URL/Program.cs
+++ b/Replace Text From PDF/C#/Replace Text From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From URL/Properties/AssemblyInfo.cs
+++ b/Replace Text From PDF/C#/Replace Text From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From Uploaded File/Program.cs
+++ b/Replace Text From PDF/C#/Replace Text From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/C#/Replace Text From Uploaded File/Properties/AssemblyInfo.cs
+++ b/Replace Text From PDF/C#/Replace Text From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/Java/Replace Text From URL/src/com/company/Main.java
+++ b/Replace Text From PDF/Java/Replace Text From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/Java/Replace Text From Uploaded File/src/com/company/Main.java
+++ b/Replace Text From PDF/Java/Replace Text From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/JavaScript/Replace Text From URL (Node.js) - Async API/app.js
+++ b/Replace Text From PDF/JavaScript/Replace Text From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/JavaScript/Replace Text From URL (Node.js)/app.js
+++ b/Replace Text From PDF/JavaScript/Replace Text From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/JavaScript/Replace Text From Uploaded File (Node.js) - Async API/app.js
+++ b/Replace Text From PDF/JavaScript/Replace Text From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/JavaScript/Replace Text From Uploaded File (Node.js)/app.js
+++ b/Replace Text From PDF/JavaScript/Replace Text From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text From PDF/VB.NET/Replace Text From URL Asynchronously/Module1.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/VB.NET/Replace Text From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/VB.NET/Replace Text From URL/Module1.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/VB.NET/Replace Text From URL/My Project/AssemblyInfo.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/VB.NET/Replace Text From Uploaded File/Module1.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text From PDF/VB.NET/Replace Text From Uploaded File/My Project/AssemblyInfo.vb
+++ b/Replace Text From PDF/VB.NET/Replace Text From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/AWS Lambda/Replace Text With Image From URL (Node.js)/app.js
+++ b/Replace Text With Image From PDF/AWS Lambda/Replace Text With Image From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Placeholder With Signature/Program.cs
+++ b/Replace Text With Image From PDF/C#/Replace Placeholder With Signature/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Placeholder With Signature/Properties/AssemblyInfo.cs
+++ b/Replace Text With Image From PDF/C#/Replace Placeholder With Signature/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From URL Asynchronously/Program.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From URL/Program.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From URL/Properties/AssemblyInfo.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From Uploaded File/Program.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/C#/Replace Text With Image From Uploaded File/Properties/AssemblyInfo.cs
+++ b/Replace Text With Image From PDF/C#/Replace Text With Image From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/Java/Replace Text With Image From URL/src/com/company/Main.java
+++ b/Replace Text With Image From PDF/Java/Replace Text With Image From URL/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/Java/Replace Text With Image From Uploaded File/src/com/company/Main.java
+++ b/Replace Text With Image From PDF/Java/Replace Text With Image From Uploaded File/src/com/company/Main.java
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Placeholder With Signature (Node.js)/app.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Placeholder With Signature (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Image From URL (Node.js) - Async API/app.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Image From URL (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Image From URL (Node.js)/app.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Image From URL (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Image From Uploaded File (Node.js) - Async API/app.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Image From Uploaded File (Node.js) - Async API/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Image From Uploaded File (Node.js)/app.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Image From Uploaded File (Node.js)/app.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/assets/flashcanvas.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/assets/flashcanvas.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/assets/json2.min.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/assets/json2.min.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/js/index.js
+++ b/Replace Text With Image From PDF/JavaScript/Replace Text With Signature (jQuery)/js/index.js
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL Asynchronously/Module1.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL Asynchronously/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL Asynchronously/My Project/AssemblyInfo.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL Asynchronously/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL/Module1.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL/My Project/AssemblyInfo.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From URL/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From Uploaded File/Module1.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From Uploaded File/Module1.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Replace Text With Image From PDF/VB.NET/Replace Text With Image From Uploaded File/My Project/AssemblyInfo.vb
+++ b/Replace Text With Image From PDF/VB.NET/Replace Text With Image From Uploaded File/My Project/AssemblyInfo.vb
@@ -1,7 +1,7 @@
 '*******************************************************************************************'
 '                                                                                           '
 ' Get API Key https://app.pdf.co/signup                                                     '
-' API Documentation: https://docs.pdf.co/api/index.html                                '
+' API Documentation: https://docs.pdf.co/api-reference                                '
 '                                                                                           '
 ' Note: Replace placeholder values in the code with your API Key                            '
 ' and file paths (if applicable)                                                            '

--- a/Translate PDF/C#/Translate PDF From URL Asynchronously/Program.cs
+++ b/Translate PDF/C#/Translate PDF From URL Asynchronously/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Translate PDF/C#/Translate PDF From URL Asynchronously/Properties/AssemblyInfo.cs
+++ b/Translate PDF/C#/Translate PDF From URL Asynchronously/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Translate PDF/C#/Translate PDF From URL/Program.cs
+++ b/Translate PDF/C#/Translate PDF From URL/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Translate PDF/C#/Translate PDF From URL/Properties/AssemblyInfo.cs
+++ b/Translate PDF/C#/Translate PDF From URL/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Translate PDF/C#/Translate PDF From Uploaded File/Program.cs
+++ b/Translate PDF/C#/Translate PDF From Uploaded File/Program.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //

--- a/Translate PDF/C#/Translate PDF From Uploaded File/Properties/AssemblyInfo.cs
+++ b/Translate PDF/C#/Translate PDF From Uploaded File/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 //*******************************************************************************************//
 //                                                                                           //
 // Get Your API Key: https://app.pdf.co/signup                                               //
-// API Documentation: https://docs.pdf.co/api/index.html                                //
+// API Documentation: https://docs.pdf.co/api-reference                                //
 //                                                                                           //
 // Note: Replace placeholder values in the code with your API Key                            //
 // and file paths (if applicable)                                                            //


### PR DESCRIPTION
Sample code comments and READMEs across the repo linked to documentation paths that no longer exist:

- `https://docs.pdf.co/api/index.html` — **404** (1,063 occurrences)
- `https://docs.pdf.co/api` in API-key registration notes — **404** (7) → now `https://app.pdf.co`, matching the 1,266 files that already use it
- `kb/Fill PDF and Add Text or Images (pdf-edit-add)/macros` — **410** (23) → `api-reference/pdf-add#macros`
- `kb/Email Send (email-send)/index` (5) → `api-reference/email/send#send-email-with-file`
- Legacy numbered slugs that only worked via redirect hops (67) → flattened to their final URLs

Every replacement target verified HTTP 200. 1,106 files changed, links only — no code changes.
